### PR TITLE
test: class-level guards (decoder no-panic matrix, ParseInstance fuzz, ASan CI)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,6 +78,38 @@ jobs:
           CGO_ENABLED: '0'
         run: go test ./... -tags nocgo -count=1 -timeout 5m
 
+  asan:
+    name: asan (cgo decoders)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.23'
+      - name: Install cgo deps (Linux)
+        run: |
+          for i in 1 2 3; do
+            if sudo apt-get update && sudo apt-get install -y \
+                libturbojpeg0-dev libopenjp2-7-dev libjxl-dev \
+                libavif-dev libwebp-dev pkg-config; then
+              exit 0
+            fi
+            sleep 10
+          done
+          exit 1
+      # AddressSanitizer over the cgo codec decoders. The committed
+      # decoder/jpeg2000/testdata fixtures (incl. the 4:2:2 subsampled tile
+      # that triggered the #7 heap over-read) are decoded here, so a
+      # regression of that bug class — in ANY cgo decoder exercised by a
+      # test — fails the build. Linux uses nohtj2k (openjph not in apt);
+      # the remaining cgo decoders (jpeg, jpeg2000, webp, avif, jpegxl) are
+      # covered. Leak detection is off (Go runtime + cgo are noisy there).
+      - name: go test -asan ./decoder/...
+        env:
+          ASAN_OPTIONS: detect_leaks=0
+        run: go test -asan -tags nohtj2k ./decoder/... -count=1 -timeout 10m
+
   # Integration suite (TestSlideParity etc.) and the parity oracle
   # require sample slides that aren't checked into the repo (they're
   # ~10 GB of WSI data, gitignored). Both are run locally before

--- a/decoder/all/conformance_test.go
+++ b/decoder/all/conformance_test.go
@@ -1,0 +1,59 @@
+package all_test
+
+import (
+	"testing"
+
+	"github.com/wsilabs/opentile-go/decoder"
+	_ "github.com/wsilabs/opentile-go/decoder/all"
+)
+
+// garbageInputs are malformed byte sequences every decoder must reject with
+// an error rather than crash. Includes empty input, random bytes, and
+// plausible-but-truncated codec headers (J2K SOC, JPEG SOI, RIFF/WEBP, etc.).
+func garbageInputs() [][]byte {
+	rand := make([]byte, 256)
+	for i := range rand {
+		rand[i] = byte(i*7 + 13)
+	}
+	return [][]byte{
+		{},                                  // empty
+		{0x00},                              // one byte
+		rand,                                // pseudo-random
+		{0xFF, 0x4F, 0xFF, 0x51, 0x00, 0x2F}, // J2K SOC+SIZ then truncated
+		{0xFF, 0xD8, 0xFF, 0xE0, 0x00},      // JPEG SOI + APP0 truncated
+		{'R', 'I', 'F', 'F', 0, 0, 0, 0, 'W', 'E', 'B', 'P'}, // WEBP container, no data
+		{0x00, 0x00, 0x00, 0x0C, 'j', 'P', 0x20, 0x20},       // JP2 box signature truncated
+	}
+}
+
+// TestDecoderNoPanicOnGarbage is the class-level guard against decoder crashes
+// on malformed input (the bug class behind the #7 OOB / suyashkumar SIGSEGV):
+// EVERY registered decoder, fed garbage, must return an error — never panic or
+// SIGSEGV. A cgo over-read would surface here (crash) under -race and -asan.
+func TestDecoderNoPanicOnGarbage(t *testing.T) {
+	names := decoder.Registered()
+	if len(names) == 0 {
+		t.Fatal("no decoders registered")
+	}
+	for _, name := range names {
+		fac, ok := decoder.Get(name)
+		if !ok {
+			t.Fatalf("Get(%q) failed", name)
+		}
+		for i, in := range garbageInputs() {
+			func() {
+				defer func() {
+					if r := recover(); r != nil {
+						t.Errorf("decoder %q panicked on garbage input #%d: %v", name, i, r)
+					}
+				}()
+				d := fac.New()
+				defer d.Close()
+				img, err := d.Decode(in, decoder.DecodeOptions{})
+				if err == nil && img == nil {
+					t.Errorf("decoder %q returned (nil, nil) on garbage input #%d", name, i)
+				}
+			}()
+		}
+	}
+}

--- a/decoder/jpeg/jpeg_cgo.go
+++ b/decoder/jpeg/jpeg_cgo.go
@@ -72,6 +72,14 @@ func (d *cgoDecoder) Decode(src []byte, opts decoder.DecodeOptions) (*decoder.Im
 	outW := (int(srcW) + scale - 1) / scale
 	outH := (int(srcH) + scale - 1) / scale
 
+	// tjDecompressHeader3 can report success with zero dimensions on some
+	// malformed/truncated inputs (observed on Linux libjpeg-turbo); guard
+	// before allocating/indexing so &dst.Pix[0] can't panic on an empty
+	// image.
+	if outW <= 0 || outH <= 0 {
+		return nil, fmt.Errorf("decoder/jpeg: invalid dimensions %dx%d: %w", outW, outH, decoder.ErrCorruptInput)
+	}
+
 	var pixelFormat C.int
 	bpp := 3
 	switch opts.Format {

--- a/internal/dicom/fuzz_test.go
+++ b/internal/dicom/fuzz_test.go
@@ -1,0 +1,33 @@
+package dicom
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// FuzzParseInstance is the class-level guard against parser crashes on
+// malformed DICOM (the bug class behind the suyashkumar/dicom HTJ2K SIGSEGV).
+// ParseInstance must always return — value or error — never panic/SIGSEGV.
+// Run: go test ./internal/dicom -run x -fuzz FuzzParseInstance -fuzztime 30s
+func FuzzParseInstance(f *testing.F) {
+	// Seed corpus: a DICM preamble with assorted trailing bytes, plus the
+	// HTJ2K transfer-syntax UID that crashed the unpatched parser.
+	preamble := make([]byte, 132)
+	copy(preamble[128:], "DICM")
+	f.Add(append(append([]byte{}, preamble...), 0xAB, 0xCD, 0xEF))
+	f.Add(append([]byte{}, preamble...))
+	f.Add(append(append([]byte{}, preamble...), []byte("1.2.840.10008.1.2.4.201")...))
+	f.Add([]byte{})
+	f.Add([]byte("not dicom at all"))
+
+	dir := f.TempDir()
+	f.Fuzz(func(t *testing.T, data []byte) {
+		p := filepath.Join(dir, "fuzz.dcm")
+		if err := os.WriteFile(p, data, 0o644); err != nil {
+			t.Skip()
+		}
+		// Must not panic / SIGSEGV. Errors are fine.
+		_, _ = ParseInstance(p)
+	})
+}


### PR DESCRIPTION
## Summary
Class-level test guards for the bug *types* found this session (not just per-instance regressions):

- **`decoder/all`: `TestDecoderNoPanicOnGarbage`** — every registered decoder, fed malformed input, must return an error, never panic/SIGSEGV. Guards the decoder-crash class across all codecs (cf. #7 JP2K OOB, suyashkumar HTJ2K SIGSEGV).
- **`internal/dicom`: `FuzzParseInstance`** — Go native fuzz; `ParseInstance` must never panic on any input (15s local run: 20k execs, 0 crashes).
- **CI `asan` job** — `go test -asan ./decoder/...` on Linux. The committed `decoder/jpeg2000/testdata` 4:2:2 fixture is decoded under AddressSanitizer, so the #7 heap-over-read class fails the build if it regresses in any cgo decoder a test exercises.

## Test Plan
- [ ] CI `test` matrix green (mac + linux)
- [ ] **CI `asan` job green** — the one I couldn't validate locally (`-asan` is unsupported on darwin/arm64; works on linux/amd64). This PR is to confirm it runs clean on the Linux runner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)