### PR TITLE
ci: integration job against public wsi-fixtures corpus

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,12 +110,65 @@ jobs:
           ASAN_OPTIONS: detect_leaks=0
         run: go test -asan -tags nohtj2k ./decoder/... -count=1 -timeout 10m
 
-  # Integration suite (TestSlideParity etc.) and the parity oracle
-  # require sample slides that aren't checked into the repo (they're
-  # ~10 GB of WSI data, gitignored). Both are run locally before
-  # release tags but skipped in CI.
+  # Integration suite against the public WSILabs/wsi-fixtures corpus.
+  # The full local sample set is ~10 GB and gitignored, but wsi-fixtures
+  # ships small CC0 versions of a subset; the integration-backed tests
+  # (TestSlideParity, the per-format reader/decoder tests) skip-if-missing,
+  # so they exercise whatever the public corpus provides. macOS gets the
+  # full codec set (incl. HTJ2K via openjph); Linux runs nohtj2k.
   #
-  # Coverage gate (make cover) is skipped for the same reason — without
-  # OPENTILE_TESTDIR the integration-backed paths report ~0% and the
-  # 80%-per-package threshold can't be met. Coverage is enforced in
-  # release-readiness sweeps where the env is provisioned.
+  # The full-fixture parity oracle (`make parity`) and the 80%-per-package
+  # coverage gate (`make cover`) still need the complete local sample set
+  # and remain release-readiness-only.
+  integration:
+    name: integration (public fixtures, Go 1.23 / ${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.23'
+
+      - name: Install cgo deps (macOS)
+        if: runner.os == 'macOS'
+        run: brew install jpeg-turbo openjpeg jpeg-xl libavif webp openjph pkg-config
+
+      - name: Install cgo deps (Linux)
+        if: runner.os == 'Linux'
+        run: |
+          for i in 1 2 3; do
+            if sudo apt-get update && sudo apt-get install -y \
+                libturbojpeg0-dev libopenjp2-7-dev libjxl-dev \
+                libavif-dev libwebp-dev pkg-config; then
+              exit 0
+            fi
+            sleep 10
+          done
+          exit 1
+
+      - name: Download public fixture corpus (WSILabs/wsi-fixtures)
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          mkdir -p "$RUNNER_TEMP/tars" "$RUNNER_TEMP/wsi-fixtures"
+          gh release download --repo WSILabs/wsi-fixtures \
+            --pattern '*.tar' --dir "$RUNNER_TEMP/tars"
+          for t in "$RUNNER_TEMP/tars"/*.tar; do
+            tar xf "$t" -C "$RUNNER_TEMP/wsi-fixtures"
+          done
+          echo "OPENTILE_TESTDIR=$RUNNER_TEMP/wsi-fixtures" >> "$GITHUB_ENV"
+          echo "corpus formats:"; ls "$RUNNER_TEMP/wsi-fixtures"
+
+      - name: go test (integration, macOS — full codecs)
+        if: runner.os == 'macOS'
+        run: go test ./... -count=1 -timeout 15m
+
+      - name: go test (integration, Linux — nohtj2k)
+        if: runner.os == 'Linux'
+        run: go test -tags nohtj2k ./... -count=1 -timeout 15m


### PR DESCRIPTION
## What

Adds an `integration` CI job (ubuntu + macos) that pulls the public [WSILabs/wsi-fixtures](https://github.com/WSILabs/wsi-fixtures) release tarballs into `OPENTILE_TESTDIR` and runs the fixture-backed test suite.

## Why

CI currently exercises **zero format readers** — the integration suite was skipped because the full local sample set is ~10 GB and gitignored. wsi-fixtures now ships small CC0 versions, so CI can finally run real fixture-backed tests.

## Coverage this lights up (verified locally, zero failures vs the v5 corpus)

- **Byte-parity** (`TestSlideParity`): SVS, NDPI, Philips, BIF, cog-wsi, DICOM (Grundium) — all PASS.
- **Decoder paths**: JPEG (NDPI), **JP2K** + **HTJ2K** (DICOM `3DHISTECH-JP2K`/`HTJ2K` via `TestDICOMJP2KDecode`/`TestDICOMHTJ2KDecode`) — the previously thin-coverage codec paths.
- macOS gets the full codec set (HTJ2K via `openjph`); Linux runs `nohtj2k`.

Tests skip-if-missing, so the job automatically tracks whatever the corpus provides (it'll grow as wsi-fixtures#2 fixtures land).

## Not changed

`make parity` (full oracle) and `make cover` (80%/pkg gate) still need the complete local sample set and remain release-readiness-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)