### PR TITLE
fix(decode): tiled LZW / uncompressed / Deflate levels now DecodedTile

### DIFF
--- a/decoded_tile.go
+++ b/decoded_tile.go
@@ -71,10 +71,30 @@ func (s *Slide) imageDecodedTile(image, level, tx, ty int, opts ...DecodeOption)
 		return nil, err
 	}
 	defer pool.Return(dec)
-	return dec.Decode(compressed, decoder.DecodeOptions{
+	dopts := decoder.DecodeOptions{
 		Scale:  cfg.scale,
 		Format: cfg.format,
-	})
+	}
+	// LZW / uncompressed / Deflate tile bytes carry no intrinsic dimensions,
+	// so the decoder requires a sized Dst (JPEG / JPEG2000 / HTJ2K / WebP /
+	// AVIF / JPEG XL / PNG self-describe and allocate their own output). A
+	// tiled TIFF tile is always TileWidth×TileLength — even at the image edge,
+	// where it is zero-padded — so the level's TileSize is the decoded size.
+	if needsExplicitTileDims(lvl.Compression) {
+		dopts.Dst = decoder.NewImageFormat(lvl.TileSize.W, lvl.TileSize.H, cfg.format)
+	}
+	return dec.Decode(compressed, dopts)
+}
+
+// needsExplicitTileDims reports whether a codec's decompressed bytes carry no
+// intrinsic dimensions, so decoding a tile through it needs a sized Dst.
+func needsExplicitTileDims(c Compression) bool {
+	switch c {
+	case CompressionLZW, CompressionNone, CompressionDeflate:
+		return true
+	default:
+		return false
+	}
 }
 
 // imageDecodedTileInto is the logic-bearing decode-into-dst read,

--- a/decoded_tile_compression_test.go
+++ b/decoded_tile_compression_test.go
@@ -1,0 +1,63 @@
+package opentile_test
+
+import (
+	"testing"
+
+	opentile "github.com/wsilabs/opentile-go"
+	"github.com/wsilabs/opentile-go/decoder"
+	_ "github.com/wsilabs/opentile-go/decoder/all"
+	_ "github.com/wsilabs/opentile-go/formats/all"
+)
+
+// TestDecodedTileTiledNonSelfDescribing covers the allocating DecodedTile path
+// on tiled levels whose codec carries no intrinsic dimensions: LZW and
+// uncompressed. The ImageScope-exported SVS fixtures use LZW / RAW tile
+// compression (vs SVS-standard JPEG/JP2K), which exposed a bug — the allocating
+// DecodedTile errored ("Dst is required") because the decode dispatch didn't
+// pass a tile-sized Dst, while RawTile / ReadRegion / DecodedTileInto worked.
+func TestDecodedTileTiledNonSelfDescribing(t *testing.T) {
+	for _, tc := range []struct {
+		rel, comp string
+	}{
+		{"svs/590_crop_lzw_imagescope.tif", "lzw"},
+		{"svs/590_crop_none_imagescope.tif", "uncompressed"},
+	} {
+		tc := tc
+		t.Run(tc.comp, func(t *testing.T) {
+			s, err := opentile.OpenFile(crossFixture(t, tc.rel))
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer s.Close()
+			l, err := s.Level(0)
+			if err != nil {
+				t.Fatal(err)
+			}
+			// A mid-grid tile (the crop's corner tiles are blank background).
+			tx, ty := l.Grid.W/2, l.Grid.H/2
+
+			img, err := l.DecodedTile(tx, ty, opentile.WithFormat(decoder.PixelFormatRGB))
+			if err != nil {
+				t.Fatalf("DecodedTile(%d,%d) on %s tiled level: %v", tx, ty, tc.comp, err)
+			}
+			if img.Width != l.TileSize.W || img.Height != l.TileSize.H {
+				t.Fatalf("decoded %dx%d, want tile %dx%d", img.Width, img.Height, l.TileSize.W, l.TileSize.H)
+			}
+			if img.Format != decoder.PixelFormatRGB {
+				t.Fatalf("format %v, want RGB", img.Format)
+			}
+			mn, mx := byte(255), byte(0)
+			for _, b := range img.Pix {
+				if b < mn {
+					mn = b
+				}
+				if b > mx {
+					mx = b
+				}
+			}
+			if mn == mx {
+				t.Fatalf("decoded to a constant image (%d) — garbage?", mn)
+			}
+		})
+	}
+}

--- a/tests/integration_test.go
+++ b/tests/integration_test.go
@@ -26,6 +26,12 @@ var slideCandidates = []string{
 	"JP2K-33003-1.svs",
 	"scan_620_.svs",
 	"svs_40x_bigtiff.svs",
+	// NOTE: the ImageScope LZW/uncompressed SVS crops (590_crop_lzw / _none,
+	// in svs/) are intentionally NOT in the parity list yet — their thumbnail
+	// associated image fails to decode (a separate multi-strip-JPEG-reassembly
+	// issue), which blocks snapshot generation. Their tiled-level decode (the
+	// codec-Dst bug they surfaced) is covered by TestDecodedTileTiledNonSelf-
+	// Describing. Add here once the thumbnail issue is resolved.
 	"CMU-1.ndpi",
 	"OS-2.ndpi",
 	"Hamamatsu-1.ndpi",


### PR DESCRIPTION
## Bug
`DecodedTile()` / `ImageDecodedTile()` errored on a **tiled level using LZW, uncompressed, or Deflate** compression: `decoder/lzw: Dst is required (decompressed bytes carry no dimensions)`. Those codecs don't self-describe their dimensions (unlike JPEG/JP2K/HTJ2K/WebP/AVIF/JPEG-XL/PNG), so the decoder needs a sized `Dst` — and the *allocating* decode path didn't pass one. `RawTile`, `ReadRegion`, `ScaledStrips`, `DecodedTileInto(dst)` were all unaffected.

Never hit before because no fixture had a tiled LZW/none/deflate **level** — only strip-based LZW *associated* images (a different path).

## Fix
Allocate a tile-sized `Dst` (the level's `TileSize` — a tiled-TIFF tile is always TileW×TileL, even zero-padded at the edge) for dimension-less codecs in `imageDecodedTile`, mirroring what the `*Into` path already does. JPEG/JP2K unchanged.

## Surfaced by
ImageScope-exported SVS files that use **LZW / RAW tile compression** (ImageScope's "TIFF" export; standard Aperio SVS is JPEG/J2K). Regression test `TestDecodedTileTiledNonSelfDescribing` covers LZW + uncompressed level decode.

## Note
The fixtures (`svs/590_crop_lzw`/`_none`) are local-only (not in the public wsi-fixtures corpus), so the regression test skips in CI — it runs locally. A separate, *unrelated* bug in those files' SVS **thumbnail** (multi-strip-JPEG reassembly) is deferred — tracked separately; it doesn't affect this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)