### PR TITLE
chore: normalize striped → stripped (convention drift)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -432,7 +432,7 @@ Bare DZI (R19) still parked but pre-prepared via internal/dzi.
 - **cgo is for codec decode only.** `internal/jpegturbo/` links libjpeg-turbo (also the `tjTransform` lossless DCT-domain crops); it is the only codec linked under *every* `cgo` build. `decoder/jpeg2000` (OpenJPEG) and `decoder/{jpegxl,webp,avif,htj2k}` (libjxl/libwebp/libavif/openjph) are each disableable via a `no<codec>` build tag — `nojp2k`, `nojxl`, `nowebp`, `noavif`, `nohtj2k` (CI builds `nohtj2k`). `internal/openslideshim/` (build tag `openslidebench`) links libopenslide for the benchmark suite only. Raw-tile reads are pure Go; under `nocgo` / `CGO_ENABLED=0` the decode paths return `ErrCGORequired` and the rest works.
 - **Ported portions under Apache 2.0** with attribution to Sectra AB retained in `NOTICE` (a license obligation — keep it even as the project grows independent). Not affiliated with or endorsed by Sectra AB or the BigPicture project.
 - **Parity with upstream is the correctness bar.** Upstream's pytest cases are ported to Go tests; a fixture-backed integration suite compares tile bytes against a committed snapshot. An opt-in `//go:build parity` harness that shells out to Python opentile is v0.2.
-- **Lock-free hot path for metadata.** Parsed IFDs, per-tile offset/length arrays, and metadata are populated at `Open()` time and immutable thereafter. `Tile()` is safe to call concurrently from many goroutines — the shared-state caches in `formats/ndpi/striped.go` (per-frame assembly cache) and `formats/ndpi/oneframe.go` (extended-frame cache) use double-checked locking and `sync.Once` respectively and produce byte-deterministic results regardless of which goroutine populates them first.
+- **Lock-free hot path for metadata.** Parsed IFDs, per-tile offset/length arrays, and metadata are populated at `Open()` time and immutable thereafter. `Tile()` is safe to call concurrently from many goroutines — the shared-state caches in `formats/ndpi/stripped.go` (per-frame assembly cache) and `formats/ndpi/oneframe.go` (extended-frame cache) use double-checked locking and `sync.Once` respectively and produce byte-deterministic results regardless of which goroutine populates them first.
 
 ## Conventions
 
@@ -442,6 +442,7 @@ Bare DZI (R19) still parked but pre-prepared via internal/dzi.
 - Format subpackages (`formats/svs/`, `formats/ndpi/`, …) are public; `formats/all` is the umbrella registration package
 - `io.ReaderAt` + `int64` size is the core input (stdlib `*os.File` satisfies concurrent-use semantics)
 - Public tile methods: `Level.Tile(x, y int)` returns raw compressed bytes; `Level.TileReader(x, y)` streams via `io.SectionReader`; `Level.Tiles(ctx)` is serial row-major via `iter.Seq2`
+- **Spelling: a strip-organised TIFF level is `stripped`, never `striped`.** The TIFF spec word is `strip` (`StripOffsets`/`StripByteCounts`/`RowsPerStrip`), so the past participle is `stripped`; `striped` derives from `stripe` (a colour band) and is the legacy v0.2 misspelling the v0.12 rename retired. The wrong spelling *looks* right, so it keeps creeping back into fresh identifiers/comments — don't reintroduce it. (Historical records — CHANGELOG, `docs/deferred.md §terminology`, milestone notes above — deliberately keep the old spelling verbatim.)
 
 ## Sample slides
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ See [Reading pixel regions and scaled strips](#reading-pixel-regions-and-scaled-
 | Format | Extension | Levels | Associated | Compression | Parity bar | Detail |
 |---|---|---|---|---|---|---|
 | **Aperio SVS** | `.svs` | tiled | label, overview, thumbnail | JPEG, JP2K (passthrough) | byte-parity vs. Python opentile | [docs/formats/svs.md](./docs/formats/svs.md) |
-| **Hamamatsu NDPI** | `.ndpi` | tiled (striped + OneFrame) | overview, synthesised label\*, Map\* | JPEG | byte-parity vs. Python opentile | [docs/formats/ndpi.md](./docs/formats/ndpi.md) |
+| **Hamamatsu NDPI** | `.ndpi` | tiled (stripped + OneFrame) | overview, synthesised label\*, Map\* | JPEG | byte-parity vs. Python opentile | [docs/formats/ndpi.md](./docs/formats/ndpi.md) |
 | **Philips TIFF** | `.tiff` | tiled, with sparse-tile fill | label, overview, thumbnail | JPEG | byte-parity vs. Python opentile | [docs/formats/philipstiff.md](./docs/formats/philipstiff.md) |
 | **OME-TIFF** | `.ome.tiff` | tiled (SubIFD) + OneFrame | overview, label, thumbnail | JPEG (uint8 RGB only) | byte-parity vs. Python opentile + tifffile | [docs/formats/ometiff.md](./docs/formats/ometiff.md) |
 | **Ventana BIF** | `.bif` | tiled, serpentine remap, with overlap metadata\* + ScanWhitePoint blank-tile fill | overview, probability\*, thumbnail | JPEG | tifffile (DP 200) + sampled-tile SHAs (both fixtures) | [docs/formats/bif.md](./docs/formats/bif.md) |
@@ -79,7 +79,7 @@ See [Reading pixel regions and scaled strips](#reading-pixel-regions-and-scaled-
 - **Optional codec libraries**, each disableable with a `no<codec>` build tag if you don't have it: OpenJPEG / JPEG 2000 (`nojp2k`), libjxl (`nojxl`), libwebp (`nowebp`), libavif (`noavif`), openjph / HTJ2K (`nohtj2k`). libjpeg-turbo is the only codec linked under every cgo build.
 - **`pkg-config`** to resolve the above at build time.
 
-opentile-go uses **cgo for codec decode** — `internal/jpegturbo/` wraps libjpeg-turbo (incl. its `tjTransform` lossless DCT-domain crops); the `decoder/*` packages link the other codec libraries above. **Raw-tile reads (`level.Tile`) are pure Go and need no cgo.** Building without cgo (`-tags nocgo` or `CGO_ENABLED=0`) is supported: raw-tile reads and SVS / NDPI-striped passthrough work; decode paths (NDPI OneFrame / edge-tile fill, Philips sparse-tile fill, OME OneFrame, and any non-JPEG codec) return `ErrCGORequired`.
+opentile-go uses **cgo for codec decode** — `internal/jpegturbo/` wraps libjpeg-turbo (incl. its `tjTransform` lossless DCT-domain crops); the `decoder/*` packages link the other codec libraries above. **Raw-tile reads (`level.Tile`) are pure Go and need no cgo.** Building without cgo (`-tags nocgo` or `CGO_ENABLED=0`) is supported: raw-tile reads and SVS / NDPI-stripped passthrough work; decode paths (NDPI OneFrame / edge-tile fill, Philips sparse-tile fill, OME OneFrame, and any non-JPEG codec) return `ErrCGORequired`.
 
 ## Install
 
@@ -299,7 +299,7 @@ Leica-SCN, COG-WSI).
 
 ### Concurrency
 
-`Level.Tile`, `Level.TileInto`, `Level.TileAt`, and `Level.TileReader` are safe to call concurrently from multiple goroutines. SVS / Philips / OME tiled / BIF / IFE have no internal locks on the tile hot path. NDPI's striped reader takes a per-page mutex on its assembled-frame cache; concurrent reads of *different* pages run in parallel, concurrent reads of the *same* page serialize. OME OneFrame is similar.
+`Level.Tile`, `Level.TileInto`, `Level.TileAt`, and `Level.TileReader` are safe to call concurrently from multiple goroutines. SVS / Philips / OME tiled / BIF / IFE have no internal locks on the tile hot path. NDPI's stripped reader takes a per-page mutex on its assembled-frame cache; concurrent reads of *different* pages run in parallel, concurrent reads of the *same* page serialize. OME OneFrame is similar.
 
 All internal caches (parsed IFDs, per-tile offset / length tables, metadata) are populated at `Open()` time and then immutable — no locks on the tile hot path. Format packages with shared lazy caches use `sync.Once` and produce byte-deterministic output regardless of which goroutine populates them first.
 

--- a/decoded_tile.go
+++ b/decoded_tile.go
@@ -34,7 +34,7 @@ type decodedTiler interface {
 // fast path succeeds, returns its output directly. ErrUnsupported from
 // the reader signals "no fast path for this level" and falls through to
 // the v0.26 RawTile + fresh-decoder path. Any other error propagates.
-// Other formats and non-striped NDPI levels keep the original RawTile +
+// Other formats and non-stripped NDPI levels keep the original RawTile +
 // fresh-decoder path, which is preserved unchanged.
 func (s *Slide) imageDecodedTile(image, level, tx, ty int, opts ...DecodeOption) (*decoder.Image, error) {
 	cfg := newDecodeConfig(opts)

--- a/docs/formats/ndpi.md
+++ b/docs/formats/ndpi.md
@@ -7,7 +7,7 @@ Hamamatsu's NanoZoomer scanner output. File extension `.ndpi`. Common in patholo
 - **TIFF dialect**: classic TIFF magic (42), but with a Hamamatsu-specific 64-bit-offset extension that lets files exceed 4 GB without committing to BigTIFF magic. Detection sniffs tag 65420 (NDPI FileFormat) in the first IFD and dispatches a custom IFD walker.
 - **Pyramid layout**: top-level IFDs. Pages alternate by `Magnification` (tag 65421, IEEE-754 single-precision); positive magnifications are pyramid levels, `Magnification == -1.0` is the overview, `-2.0` is the Map page.
 - **Compression**: JPEG only.
-- **Pyramid level shapes**: each level is a single big JPEG ("OneFrame") OR a striped JPEG with restart markers driving stripe boundaries (the McuStarts table at tag 65426 lists per-stripe RST offsets).
+- **Pyramid level shapes**: each level is a single big JPEG ("OneFrame") OR a stripped JPEG with restart markers driving strip boundaries (the McuStarts table at tag 65426 lists per-strip RST offsets).
 
 ## What's supported
 
@@ -74,7 +74,7 @@ NDPI's pixel-size lives on the per-axis TIFF resolution tags — and on every fi
 - Our metadata accessor: `ndpi.MetadataOf(opentile.Tiler) (*Metadata, bool)`.
 - Shared OneFrame machinery: `internal/oneframe/` (factored from NDPI in v0.6 to support OME-TIFF).
 - Upstream Python: [`opentile/formats/ndpi/`](https://github.com/imi-bigpicture/opentile/tree/main/opentile/formats/ndpi).
-- The `__need_fill_background` gate ported from PyTurboJPEG (`turbojpeg.py:839-863`); see `formats/ndpi/striped.go`.
+- The `__need_fill_background` gate ported from PyTurboJPEG (`turbojpeg.py:839-863`); see `formats/ndpi/stripped.go`.
 
 ## Known issues + history
 

--- a/docs/opentile-go-svs-perf.md
+++ b/docs/opentile-go-svs-perf.md
@@ -2,7 +2,7 @@
 
 **Audience.** Maintainers of [`opentile-go`](https://github.com/wsilabs/opentile-go) and authors of HTTP / desktop / pipeline consumers that read SVS pyramids through it.
 
-**Scope.** Aperio SVS files specifically. Most ideas transfer to NDPI but NDPI's striped path has different concurrency characteristics (per-page mutex) and is called out where it matters.
+**Scope.** Aperio SVS files specifically. Most ideas transfer to NDPI but NDPI's stripped path has different concurrency characteristics (per-page mutex) and is called out where it matters.
 
 **Status.** Recommendations, not a binding plan. Pick what's useful for your workload. Predates the v0.26+ work; for the `ScaledStrips` region/DZI iterator and byte-bounded memory budgeting (v0.30) plus the cross-format benchmark suite, see [`perf.md`](./perf.md).
 
@@ -173,13 +173,13 @@ type Tiler interface {
 
 - Returned `Tile()` byte slices are caller-owned (current behavior — caller may modify them).
 - For SVS specifically: zero internal locks; goroutine count is limited by OS file descriptors and page cache capacity, not opentile.
-- For NDPI striped path: per-page mutex; concurrent reads of *different* pages are concurrent, concurrent reads of the *same* page serialize.
+- For NDPI stripped path: per-page mutex; concurrent reads of *different* pages are concurrent, concurrent reads of the *same* page serialize.
 - `Close()` must not race with in-flight tile reads. (Already documented; keep.)
 - If §A.1 lands and any borrowed-slice API is added later, document the alias-the-mapping rule explicitly.
 
 **Impact.** Documentation only. Lets consumers reason about their scaling budget without reading source.
 
-**Effort.** ~20 lines across `tiler.go`, `formats/svs/svs.go`, `formats/ndpi/striped.go`.
+**Effort.** ~20 lines across `tiler.go`, `formats/svs/svs.go`, `formats/ndpi/stripped.go`.
 
 **Risks.** None.
 
@@ -322,7 +322,7 @@ Listed because each comes up repeatedly in tile-server perf discussions and is u
 
 ## A note on NDPI
 
-Most of §A.1 (mmap), §A.4 (WarmLevel), and all of §B apply unchanged. NDPI's striped path has per-page mutexes; concurrency is across pages, not within one. §A.2 (TileInto) is harder — the striped reassembly buffer is already an internal scratch space, so the API would need to be designed differently. §A.3 (splice template) doesn't apply directly because NDPI tiles are reassembled, not table-spliced.
+Most of §A.1 (mmap), §A.4 (WarmLevel), and all of §B apply unchanged. NDPI's stripped path has per-page mutexes; concurrency is across pages, not within one. §A.2 (TileInto) is harder — the stripped reassembly buffer is already an internal scratch space, so the API would need to be designed differently. §A.3 (splice template) doesn't apply directly because NDPI tiles are reassembled, not table-spliced.
 
 If your consumer mixes SVS and NDPI in the same harness, §A.1 still wins for both. Don't expect linear scaling under NDPI for tiles within the same page.
 

--- a/docs/perf.md
+++ b/docs/perf.md
@@ -129,7 +129,7 @@ population) is the same.
 
 - **Tile reads are concurrent-safe** on every format. SVS / Philips /
   OME tiled / BIF / IFE have no internal locks on the tile hot path.
-  NDPI's striped reader takes a per-page mutex on its assembled-frame
+  NDPI's stripped reader takes a per-page mutex on its assembled-frame
   cache; concurrent reads of *different* pages run in parallel,
   concurrent reads of the *same* page serialize. OME OneFrame is
   similar.
@@ -153,7 +153,7 @@ Measurements on Apple M4 (darwin/arm64) under warm-cache pool TileInto:
 | **SVS** | 240×240 | **99.7** | **0** | In-place splice (v0.9 T8) |
 | **Philips** | 512×512 | **425** | **0** | In-place splice (v0.9 T8) |
 | Ventana BIF | 1024×1024 | 3,225 | 0 | Larger tiles, more memcpy |
-| NDPI striped | 512×512 | 185k (parallel) | 4 | CPU-bound libjpeg-turbo crop |
+| NDPI stripped | 512×512 | 185k (parallel) | 4 | CPU-bound libjpeg-turbo crop |
 
 NDPI is the outlier. Per-tile work includes a libjpeg-turbo
 `tjTransform` pass (DCT-domain crop), which is genuinely CPU-bound

--- a/formats/cogwsi/validation.go
+++ b/formats/cogwsi/validation.go
@@ -154,7 +154,7 @@ func collectLevels(es []pyrEntry) []uint32 {
 }
 
 // pageIsTiled reports whether the IFD has TileWidth + TileLength
-// tags (== tiled storage, not striped). internal/tiff doesn't
+// tags (== tiled storage, not stripped). internal/tiff doesn't
 // expose an IsTiled() helper as of v0.19; we read the tags
 // directly via ScalarU32.
 func pageIsTiled(p *tiff.Page) bool {

--- a/formats/cogwsi/validation_test.go
+++ b/formats/cogwsi/validation_test.go
@@ -81,7 +81,7 @@ func TestValidateIFDs_SpecViolations(t *testing.T) {
 			},
 		},
 		{
-			// WSIImageType=pyramid on a striped IFD (no TileWidth/Length).
+			// WSIImageType=pyramid on a stripped IFD (no TileWidth/Length).
 			name: "pyramid IFD not tiled",
 			build: func() []byte {
 				return buildMultiIFDTIFF(t, []ifdSpec{
@@ -141,7 +141,7 @@ func TestValidateIFDs_SpecViolations(t *testing.T) {
 // ifdSpec describes how to assemble one synthetic IFD for the
 // validation tests. Only the WSI-tag-relevant knobs are exposed —
 // every IFD gets the same minimal structural skeleton (ImageWidth=
-// ImageLength=512, 8-bit YCbCr JPEG; tiled vs striped controlled
+// ImageLength=512, 8-bit YCbCr JPEG; tiled vs stripped controlled
 // by the tiled bool).
 type ifdSpec struct {
 	tiled         bool

--- a/formats/ndpi/tiler.go
+++ b/formats/ndpi/tiler.go
@@ -38,19 +38,19 @@ type ndpiWarmer interface {
 
 // tiler is the NDPI implementation of format.Reader.
 type tiler struct {
-	md          Metadata
-	images      []opentile.Pyramid
-	levelImpls  []ndpiLevel // parallel to images[0].Levels
-	associated  []opentile.AssociatedImage
-	icc         []byte
-	dirSpecs    []ndpiDirSpec // page→role mapping captured at Open; used by TIFFDirectories
+	md         Metadata
+	images     []opentile.Pyramid
+	levelImpls []ndpiLevel // parallel to images[0].Levels
+	associated []opentile.AssociatedImage
+	icc        []byte
+	dirSpecs   []ndpiDirSpec // page→role mapping captured at Open; used by TIFFDirectories
 }
 
-func (t *tiler) Format() opentile.Format              { return opentile.FormatNDPI }
-func (t *tiler) Pyramids() []opentile.Pyramid         { return t.images }
+func (t *tiler) Format() opentile.Format                      { return opentile.FormatNDPI }
+func (t *tiler) Pyramids() []opentile.Pyramid                 { return t.images }
 func (t *tiler) AssociatedImages() []opentile.AssociatedImage { return t.associated }
-func (t *tiler) Metadata() opentile.Metadata            { return t.md.Metadata }
-func (t *tiler) ICCProfile() []byte                     { return t.icc }
+func (t *tiler) Metadata() opentile.Metadata                  { return t.md.Metadata }
+func (t *tiler) ICCProfile() []byte                           { return t.icc }
 func (t *tiler) Close() error {
 	// v0.27: release each strippedImage's long-lived decoder handle.
 	var firstErr error
@@ -69,8 +69,8 @@ func (t *tiler) Close() error {
 // reader against the unexported decodedTiler interface and calls
 // this method when it matches.
 //
-// For striped levels (the common case), delegates to
-// strippedImage.DecodedTile. For non-striped levels (oneframe,
+// For stripped levels (the common case), delegates to
+// strippedImage.DecodedTile. For non-stripped levels (oneframe,
 // associated images), returns fastpath.ErrUnsupported to signal the
 // caller to fall back to the slow path.
 //

--- a/formats/svs/associated.go
+++ b/formats/svs/associated.go
@@ -13,22 +13,22 @@ import (
 )
 
 // newAssociatedImage dispatches construction by the IFD's actual compression,
-// not by image role. Canonical Aperio stores thumbnail/overview as striped
+// not by image role. Canonical Aperio stores thumbnail/overview as stripped
 // JPEG (assembled via ConcatenateScans) and the label as LZW; but ImageScope
 // can re-export any associated image as LZW or uncompressed to match the
 // pyramid's tile codec (GH #29 — an LZW thumbnail must not be routed to the
-// JPEG-reassembly path). JPEG (tag 7) goes through the striped-JPEG assembler;
+// JPEG-reassembly path). JPEG (tag 7) goes through the stripped-JPEG assembler;
 // every other codec (LZW / uncompressed / Deflate) goes through the
 // compression-aware strip path, which reverses the predictor and stacks strips.
 func newAssociatedImage(imageType opentile.AssociatedType, p *tiff.Page, r io.ReaderAt) (opentile.AssociatedImage, error) {
 	comp, _ := p.Compression()
 	if comp == 7 { // JPEG
-		return newStripedJPEGAssociated(imageType, p, r)
+		return newStrippedJPEGAssociated(imageType, p, r)
 	}
-	return newStripedAssociated(imageType, p, r)
+	return newStrippedAssociated(imageType, p, r)
 }
 
-// stripedJPEGAssociated is the SVS AssociatedImage implementation for
+// strippedJPEGAssociated is the SVS AssociatedImage implementation for
 // thumbnail and overview pages. Bytes() assembles a standalone JPEG from the
 // TIFF strips via internal/jpeg.ConcatenateScans, injecting the page's
 // JPEGTables and an APP14 "Adobe" marker to signal RGB colorspace (Aperio
@@ -38,7 +38,7 @@ func newAssociatedImage(imageType opentile.AssociatedType, p *tiff.Page, r io.Re
 // time via jpeg.MCUSizeOf on the first strip (with JPEGTables prepended when
 // the strips themselves don't carry SOF tables). Used for DRI / restart-
 // interval computation in Bytes().
-type stripedJPEGAssociated struct {
+type strippedJPEGAssociated struct {
 	imageType    opentile.AssociatedType
 	size         opentile.Size
 	stripOffsets []uint64
@@ -53,15 +53,15 @@ type stripedJPEGAssociated struct {
 	tiffTags     opentile.TIFFTags
 }
 
-func (a *stripedJPEGAssociated) Type() opentile.AssociatedType     { return a.imageType }
-func (a *stripedJPEGAssociated) Size() opentile.Size               { return a.size }
-func (a *stripedJPEGAssociated) Compression() opentile.Compression { return opentile.CompressionJPEG }
+func (a *strippedJPEGAssociated) Type() opentile.AssociatedType     { return a.imageType }
+func (a *strippedJPEGAssociated) Size() opentile.Size               { return a.size }
+func (a *strippedJPEGAssociated) Compression() opentile.Compression { return opentile.CompressionJPEG }
 
 // Decode returns the decoded pixels. It first tries the assembled standalone
 // JPEG (Bytes() via ConcatenateScans); if libjpeg rejects it (some Aperio
 // strip layouts produce "extraneous bytes before marker"), it falls back to
 // decoding each strip's abbreviated JPEG independently and stacking them.
-func (a *stripedJPEGAssociated) Decode(opts decoder.DecodeOptions) (*decoder.Image, error) {
+func (a *strippedJPEGAssociated) Decode(opts decoder.DecodeOptions) (*decoder.Image, error) {
 	if data, err := a.Bytes(); err == nil {
 		if img, derr := assocdecode.ViaCodec(opentile.CompressionJPEG, data, opts); derr == nil {
 			return img, nil
@@ -72,7 +72,7 @@ func (a *stripedJPEGAssociated) Decode(opts decoder.DecodeOptions) (*decoder.Ima
 
 // decodeStripStack decodes each strip's abbreviated JPEG (tables in
 // JPEGTables, RGB via APP14) and stacks them vertically by decoded height.
-func (a *stripedJPEGAssociated) decodeStripStack(opts decoder.DecodeOptions) (*decoder.Image, error) {
+func (a *strippedJPEGAssociated) decodeStripStack(opts decoder.DecodeOptions) (*decoder.Image, error) {
 	if opts.Scale > 1 {
 		return nil, decoder.ErrUnsupportedScale
 	}
@@ -121,7 +121,7 @@ func (a *stripedJPEGAssociated) decodeStripStack(opts decoder.DecodeOptions) (*d
 	return full, nil
 }
 
-func (a *stripedJPEGAssociated) Bytes() ([]byte, error) {
+func (a *strippedJPEGAssociated) Bytes() ([]byte, error) {
 	fragments := make([][]byte, len(a.stripOffsets))
 	for i := range a.stripOffsets {
 		buf := make([]byte, a.stripCounts[i])
@@ -205,7 +205,7 @@ func parseFirstSOF(frag []byte) (*jpeg.SOF, error) {
 // Encoding returns the abbreviated-JPEG strips + JPEGTables for
 // faithful standalone re-emission (GH #22). A consumer writes the strips +
 // tag 347 (JPEGTables) verbatim into a fresh IFD.
-func (a *stripedJPEGAssociated) Encoding() (opentile.AssociatedEncoding, bool) {
+func (a *strippedJPEGAssociated) Encoding() (opentile.AssociatedEncoding, bool) {
 	strips, err := readStrips(a.reader, a.stripOffsets, a.stripCounts)
 	if err != nil {
 		return opentile.AssociatedEncoding{}, false
@@ -221,7 +221,7 @@ func (a *stripedJPEGAssociated) Encoding() (opentile.AssociatedEncoding, bool) {
 }
 
 // TIFFTags returns the parsed TIFF tags of this associated image's backing IFD.
-func (a *stripedJPEGAssociated) TIFFTags() (opentile.TIFFTags, bool) {
+func (a *strippedJPEGAssociated) TIFFTags() (opentile.TIFFTags, bool) {
 	if a.tiffTags == nil {
 		return nil, false
 	}
@@ -229,14 +229,14 @@ func (a *stripedJPEGAssociated) TIFFTags() (opentile.TIFFTags, bool) {
 }
 
 // IFDOffset returns the byte offset of this associated image's backing IFD.
-func (a *stripedJPEGAssociated) IFDOffset() (int64, bool) {
+func (a *strippedJPEGAssociated) IFDOffset() (int64, bool) {
 	if a.ifdOffset <= 0 {
 		return 0, false
 	}
 	return a.ifdOffset, true
 }
 
-func newStripedJPEGAssociated(imageType opentile.AssociatedType, p *tiff.Page, r io.ReaderAt) (*stripedJPEGAssociated, error) {
+func newStrippedJPEGAssociated(imageType opentile.AssociatedType, p *tiff.Page, r io.ReaderAt) (*strippedJPEGAssociated, error) {
 	iw, ok := p.ImageWidth()
 	if !ok {
 		return nil, fmt.Errorf("svs: associated %s ImageWidth missing", imageType)
@@ -290,7 +290,7 @@ func newStripedJPEGAssociated(imageType opentile.AssociatedType, p *tiff.Page, r
 	rps, _ := p.ScalarU32(tiff.TagRowsPerStrip)
 	spp, _ := p.SamplesPerPixel()
 	photo, _ := p.Photometric()
-	return &stripedJPEGAssociated{
+	return &strippedJPEGAssociated{
 		imageType:    imageType,
 		size:         opentile.Size{W: int(iw), H: int(il)},
 		stripOffsets: offsets,
@@ -307,14 +307,14 @@ func newStripedJPEGAssociated(imageType opentile.AssociatedType, p *tiff.Page, r
 	}, nil
 }
 
-// stripedAssociated is the SVS AssociatedImage implementation for any
+// strippedAssociated is the SVS AssociatedImage implementation for any
 // non-JPEG associated image (label, and — for ImageScope re-exports —
 // thumbnail/overview too). Compression varies (LZW=5 in all three CMU
 // labels, but can be uncompressed or Deflate); upstream SvsLabelImage
 // returns the raw first strip bytes and advertises whatever Compression the
 // TIFF carries. imageType records the page's role so Type() reports it
 // faithfully regardless of which codec the strips use.
-type stripedAssociated struct {
+type strippedAssociated struct {
 	imageType    opentile.AssociatedType
 	size         opentile.Size
 	compression  opentile.Compression
@@ -329,16 +329,16 @@ type stripedAssociated struct {
 	tiffTags     opentile.TIFFTags
 }
 
-func (a *stripedAssociated) Type() opentile.AssociatedType     { return a.imageType }
-func (a *stripedAssociated) Size() opentile.Size               { return a.size }
-func (a *stripedAssociated) Compression() opentile.Compression { return a.compression }
+func (a *strippedAssociated) Type() opentile.AssociatedType     { return a.imageType }
+func (a *strippedAssociated) Size() opentile.Size               { return a.size }
+func (a *strippedAssociated) Compression() opentile.Compression { return a.compression }
 
 // Decode returns the faithfully-decoded label pixels. Unlike Bytes() — which
 // re-encodes LZW and drops the predictor — this decompresses the strips,
 // reverses Predictor=2 horizontal differencing, and interprets the samples
 // as RGB(A) (GH #20). Strip-based codecs only (LZW / Deflate / none); the
 // CMU Aperio labels are LZW + Predictor=2.
-func (a *stripedAssociated) Decode(opts decoder.DecodeOptions) (*decoder.Image, error) {
+func (a *strippedAssociated) Decode(opts decoder.DecodeOptions) (*decoder.Image, error) {
 	strips := make([][]byte, len(a.stripOffsets))
 	for i := range a.stripOffsets {
 		buf := make([]byte, a.stripCounts[i])
@@ -368,7 +368,7 @@ func (a *stripedAssociated) Decode(opts decoder.DecodeOptions) (*decoder.Image, 
 // Python opentile 0.20.0 SvsLabelImage.get_tile((0,0)) which returns only
 // strip 0 — a long-standing upstream bug; we'll file a PR there separately
 // so parity can re-engage once Python lands the same fix.
-func (a *stripedAssociated) Bytes() ([]byte, error) {
+func (a *strippedAssociated) Bytes() ([]byte, error) {
 	if len(a.stripOffsets) == 0 || len(a.stripCounts) == 0 {
 		return nil, fmt.Errorf("svs: %s has no strips", a.imageType)
 	}
@@ -413,7 +413,7 @@ func (a *stripedAssociated) Bytes() ([]byte, error) {
 // Encoding returns the LZW label's source strips + tags for faithful
 // standalone re-emission (GH #22). The label keeps Predictor (typically 2);
 // a consumer MUST emit tag 317 or the differencing isn't reversed.
-func (a *stripedAssociated) Encoding() (opentile.AssociatedEncoding, bool) {
+func (a *strippedAssociated) Encoding() (opentile.AssociatedEncoding, bool) {
 	strips, err := readStrips(a.reader, a.stripOffsets, a.stripCounts)
 	if err != nil {
 		return opentile.AssociatedEncoding{}, false
@@ -429,7 +429,7 @@ func (a *stripedAssociated) Encoding() (opentile.AssociatedEncoding, bool) {
 }
 
 // TIFFTags returns the parsed TIFF tags of this associated image's backing IFD.
-func (a *stripedAssociated) TIFFTags() (opentile.TIFFTags, bool) {
+func (a *strippedAssociated) TIFFTags() (opentile.TIFFTags, bool) {
 	if a.tiffTags == nil {
 		return nil, false
 	}
@@ -437,14 +437,14 @@ func (a *stripedAssociated) TIFFTags() (opentile.TIFFTags, bool) {
 }
 
 // IFDOffset returns the byte offset of this associated image's backing IFD.
-func (a *stripedAssociated) IFDOffset() (int64, bool) {
+func (a *strippedAssociated) IFDOffset() (int64, bool) {
 	if a.ifdOffset <= 0 {
 		return 0, false
 	}
 	return a.ifdOffset, true
 }
 
-func newStripedAssociated(imageType opentile.AssociatedType, p *tiff.Page, r io.ReaderAt) (*stripedAssociated, error) {
+func newStrippedAssociated(imageType opentile.AssociatedType, p *tiff.Page, r io.ReaderAt) (*strippedAssociated, error) {
 	iw, ok := p.ImageWidth()
 	if !ok {
 		return nil, fmt.Errorf("svs: %s ImageWidth missing", imageType)
@@ -466,7 +466,7 @@ func newStripedAssociated(imageType opentile.AssociatedType, p *tiff.Page, r io.
 	spp, _ := p.SamplesPerPixel()
 	pred, _ := p.Predictor()
 	photo, _ := p.Photometric()
-	return &stripedAssociated{
+	return &strippedAssociated{
 		imageType:    imageType,
 		size:         opentile.Size{W: int(iw), H: int(il)},
 		compression:  tiffCompressionToOpentile(comp),

--- a/formats/svs/associated_test.go
+++ b/formats/svs/associated_test.go
@@ -45,7 +45,7 @@ func TestLabelMultiStripDecodesRestitchesEncodes(t *testing.T) {
 		counts = append(counts, uint64(enc.Len()))
 		off += uint64(enc.Len())
 	}
-	a := &stripedAssociated{
+	a := &strippedAssociated{
 		imageType:    opentile.AssociatedLabel,
 		stripOffsets: offsets,
 		stripCounts:  counts,
@@ -74,7 +74,7 @@ func TestLabelMultiStripDecodesRestitchesEncodes(t *testing.T) {
 // without any JPEG assembly (upstream SvsLabelImage.get_tile semantics).
 func TestLabelSingleStripPassthrough(t *testing.T) {
 	payload := []byte("this is a fake LZW strip body")
-	a := &stripedAssociated{
+	a := &strippedAssociated{
 		imageType:    opentile.AssociatedLabel,
 		stripOffsets: []uint64{0},
 		stripCounts:  []uint64{uint64(len(payload))},

--- a/internal/oneframe/oneframe.go
+++ b/internal/oneframe/oneframe.go
@@ -131,9 +131,9 @@ func (l *Image) Size() opentile.Size               { return l.size }
 func (l *Image) TileSize() opentile.Size           { return l.tileSize }
 func (l *Image) Grid() opentile.Size               { return l.grid }
 func (l *Image) Compression() opentile.Compression { return l.compression }
-func (l *Image) MPP() opentile.MPP                  { return l.mpp }
+func (l *Image) MPP() opentile.MPP                 { return l.mpp }
 func (l *Image) FocalPlane() float64               { return 0 }
-func (l *Image) TileOverlap() opentile.Point          { return opentile.Point{} }
+func (l *Image) TileOverlap() opentile.Point       { return opentile.Point{} }
 
 // TileAt is the multi-dim entry point. NDPI/OME OneFrame levels
 // are 2D-only; non-zero Z/C/T yields ErrDimensionUnavailable.
@@ -147,7 +147,7 @@ func (l *Image) TileAt(coord opentile.TileCoord) ([]byte, error) {
 // TileMaxSize returns a generous upper bound for compressed tile
 // output. OneFrame's libjpeg-turbo crop output size depends on
 // entropy coding; we return tileSize.W * tileSize.H as a worst-case
-// bound (one byte per pixel) consistent with NDPI striped's
+// bound (one byte per pixel) consistent with NDPI stripped's
 // approach.
 func (l *Image) TileMaxSize() int { return l.tileSize.W * l.tileSize.H }
 

--- a/internal/tiff/page.go
+++ b/internal/tiff/page.go
@@ -254,7 +254,7 @@ func (p *Page) ScalarArrayU32(tag uint16) ([]uint32, error) {
 // HasTag reports whether the page carries the given tag at all, without
 // attempting to decode its value. Useful when a format needs to branch on
 // tag presence before paying the decode cost — e.g., NDPI's McuStarts
-// (65426) tag determines whether a page is a striped JPEG level.
+// (65426) tag determines whether a page is a stripped JPEG level.
 func (p *Page) HasTag(tag uint16) bool {
 	_, ok := p.ifd.get(tag)
 	return ok

--- a/tests/ndpi_decodedtile_parity_test.go
+++ b/tests/ndpi_decodedtile_parity_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 // TestNDPIDecodedTilePathParity walks each NDPI fixture and asserts
-// that DecodedTile (v0.27 fast path for striped levels, slow-path
+// that DecodedTile (v0.27 fast path for stripped levels, slow-path
 // fallback for oneframe) returns the same pixels as RawTile + decode
 // on a sampled scatter of interior tiles per level.
 //

--- a/tests/parity/perf_baseline_test.go
+++ b/tests/parity/perf_baseline_test.go
@@ -39,7 +39,7 @@ import (
 
 // benchFixtures lists one representative slide per format. The
 // chosen fixtures are the smallest-but-meaningful sample for each:
-// CMU-1.svs (177 MB tiled JPEG SVS), CMU-1.ndpi (188 MB striped),
+// CMU-1.svs (177 MB tiled JPEG SVS), CMU-1.ndpi (188 MB stripped),
 // Philips-1.tiff (311 MB), Leica-1.ome.tiff (689 MB single-pyramid
 // OME), Ventana-1.bif (227 MB DP 200), cervix_2x_jpeg.iris (2.16 GB).
 // Bench focuses on level 0 — the hot path consumers care about.


### PR DESCRIPTION
## Summary
Cosmetic consistency pass. The TIFF spec word is **strip** (`StripOffsets` / `StripByteCounts` / `RowsPerStrip`), so a strip-organised level is **stripped**; **striped** derives from *stripe* (a colour band) and is the legacy v0.2 misspelling the v0.12 rename retired. The wrong spelling *looks* right, so it kept creeping back into fresh identifiers/comments — including code added this session in `formats/svs/associated.go`.

46 stray one-p `striped` → `stripped`. All renamed identifiers are **unexported** — zero public-API impact, no consumer (wsitools/openscope) breakage.

## Scope
**Normalized** (active source + current docs):
- `formats/svs/associated.go` + test: `striped{JPEG,}Associated` → `stripped*`
- stray comments in `decoded_tile.go`, `formats/ndpi/tiler.go`, `formats/cogwsi/validation{,_test}.go`, `internal/tiff/page.go`, `internal/oneframe/oneframe.go`, two `tests/` files
- `README.md`, `docs/formats/ndpi.md`, `docs/perf.md`, `docs/opentile-go-svs-perf.md` — also repairs stale `formats/ndpi/striped.go` filename refs (the file is `stripped.go` since v0.12)
- `CLAUDE.md`: fixed the `striped.go` filename ref in **Invariants**; added a Conventions line documenting the strip/stripe distinction to stop recurrence

**Left verbatim** (point-in-time records that intentionally quote the old spelling): `CHANGELOG.md`, `docs/deferred.md §terminology`, `docs/superpowers/specs|notes/`, CLAUDE.md milestone notes.

## Test Plan
- [x] `go build ./...` + `go vet ./...` clean
- [x] `gofmt` clean (folded in pre-existing alignment drift in `tiler.go`/`oneframe.go`)
- [x] `formats/svs`, `formats/ndpi`, `formats/cogwsi`, `internal/oneframe`, `internal/tiff`, root, `./tests/...` (incl. parity) all green under `-race`
- [x] grep confirms no one-p `striped` remains outside the historical records listed above

🤖 Generated with [Claude Code](https://claude.com/claude-code)