### PR TITLE
fix(bif): detect legacy classic-TIFF iScan slides (don't require BigTIFF) (#37)

### DIFF
--- a/bif_legacy_classictiff_test.go
+++ b/bif_legacy_classictiff_test.go
@@ -1,0 +1,89 @@
+//go:build cgo && !nocgo
+
+package opentile_test
+
+import (
+	"testing"
+
+	opentile "github.com/wsilabs/opentile-go"
+	"github.com/wsilabs/opentile-go/decoder"
+	_ "github.com/wsilabs/opentile-go/decoder/all"
+	_ "github.com/wsilabs/opentile-go/formats/all"
+)
+
+// TestLegacyClassicTIFFBIF is the #37 regression: legacy iScan scanners
+// (Coreo/HT, ~2010-2012, BuildVersion 3.x) wrote BIF as *classic* (non-BigTIFF)
+// little-endian TIFF. opentile-go's BIF detection used to require BigTIFF, so
+// these slides fell through to the generic-TIFF reader, which renders BIF's
+// serpentine tile order scrambled (the "corrupt BIF" symptom in viewers) — or
+// failed to open at all. After the detection fix they must open through the BIF
+// reader (which de-serpentines the tile order) and read cleanly.
+//
+// These are real clinical slides (PHI in the labels / accession-numbered
+// filenames), so they live only in the local gitignored sample set and are
+// never published to the public corpus — the test skips when they're absent
+// (always in CI). The synthetic classic-TIFF detection case is covered in CI by
+// formats/bif.TestSupportsClassicTIFFWithIScan.
+func TestLegacyClassicTIFFBIF(t *testing.T) {
+	for _, rel := range []string{
+		"bif/1_19.bif",
+		"bif/AC1.592.bif",
+		"bif/S12-18199-1A.bif",
+	} {
+		rel := rel
+		t.Run(rel, func(t *testing.T) {
+			s, err := opentile.OpenFile(crossFixture(t, rel)) // t.Skip if missing
+			if err != nil {
+				t.Fatalf("OpenFile: %v", err)
+			}
+			defer s.Close()
+
+			// Must be claimed by the BIF reader — not generic-TIFF (which would
+			// scramble the serpentine layout) and not rejected as unknown.
+			if s.Format() != opentile.FormatBIF {
+				t.Fatalf("format = %s, want bif (legacy classic-TIFF iScan must route to the BIF reader)", s.Format())
+			}
+
+			p := s.Pyramid(0)
+			if len(p.Levels) < 2 {
+				t.Fatalf("levels = %d, want a multi-level pyramid", len(p.Levels))
+			}
+
+			// Read every tile of the smallest level; none must error.
+			li := len(p.Levels) - 1
+			lv, err := s.Level(li)
+			if err != nil {
+				t.Fatalf("Level(%d): %v", li, err)
+			}
+			g := p.Levels[li].Grid
+			for y := 0; y < g.H; y++ {
+				for x := 0; x < g.W; x++ {
+					if _, err := lv.Tile(x, y); err != nil {
+						t.Fatalf("smallest-level Tile(%d,%d): %v", x, y, err)
+					}
+				}
+			}
+
+			// A mid-grid base tile decodes to the level's tile size with content.
+			base, err := s.Level(0)
+			if err != nil {
+				t.Fatalf("Level(0): %v", err)
+			}
+			bg := p.Levels[0].Grid
+			img, err := base.DecodedTile(bg.W/2, bg.H/2, opentile.WithFormat(decoder.PixelFormatRGB))
+			if err != nil {
+				t.Fatalf("L0 DecodedTile: %v", err)
+			}
+			if img.Width != p.Levels[0].TileSize.W || img.Height != p.Levels[0].TileSize.H {
+				t.Errorf("decoded %dx%d, want tile %dx%d", img.Width, img.Height, p.Levels[0].TileSize.W, p.Levels[0].TileSize.H)
+			}
+
+			// Associated images (label/overview) are present and decode.
+			for _, a := range s.AssociatedImages() {
+				if _, err := a.Decode(decoder.DecodeOptions{Format: decoder.PixelFormatRGB}); err != nil {
+					t.Errorf("associated %q Decode: %v", a.Type(), err)
+				}
+			}
+		})
+	}
+}

--- a/formats/bif/detection.go
+++ b/formats/bif/detection.go
@@ -14,22 +14,27 @@ import (
 // without an XML element).
 const iScanMarker = "<iScan"
 
-// Detect reports whether file is a BIF candidate. The rule, per spec
-// §5.1: BigTIFF AND at least one IFD's XMP packet (TIFF tag 700)
-// contains the substring `<iScan`. Both predicates are necessary —
-// classic-TIFF iScan files don't exist (the BIF whitepaper mandates
-// BigTIFF), and the substring catches both spec-compliant DP scanners
-// (whose IFD 0 XMP starts `<?xml ... ?><Metadata><iScan ...>`) and
-// legacy iScan slides (whose IFD 0 XMP starts directly `<iScan ...>`).
+// Detect reports whether file is a BIF candidate. The rule: at least one
+// IFD's XMP packet (TIFF tag 700) contains the substring `<iScan`. This
+// mirrors openslide's detection (`INITIAL_XML_ISCAN = "iScan"`), which keys
+// solely on the XMP marker — and catches both spec-compliant DP scanners
+// (whose IFD 0 XMP starts `<?xml ... ?><Metadata><iScan ...>`) and legacy
+// iScan slides (whose IFD 0 XMP starts directly `<iScan ...>`).
 //
-// Verified across all 17 sample fixtures: 2 BIFs match, 0 false
-// positives across the 15 non-BIF fixtures (5 SVS, 3 NDPI, 1 generic
-// TIFF, 2 OME-TIFF, 4 Philips TIFF). See `docs/deferred.md §9 → v0.7
-// gates → Task 1` for the gate outcome record.
+// The marker alone is the discriminator — we do NOT additionally require
+// BigTIFF. The BIF whitepaper mandates BigTIFF for the DP generation, but
+// legacy iScan scanners (Coreo/HT, ~2010-2012, BuildVersion 3.x) wrote
+// *classic* little-endian TIFF. The earlier BigTIFF gate wrongly rejected
+// those, so they fell through to the generic-TIFF reader, which renders BIF's
+// serpentine (boustrophedon, bottom-up) tile order scrambled — the "corrupt
+// BIF" symptom in downstream viewers (#37). The serpentine + blank-tile +
+// associated-image machinery is container-agnostic (it operates on parsed
+// pages), so the reader handles classic-TIFF iScan slides once detected.
+//
+// The `<iScan` substring is BIF-specific: verified 0 false positives across
+// the non-BIF fixtures (SVS, NDPI, generic TIFF, OME-TIFF, Philips TIFF), none
+// of which carry an `<iScan` XMP element.
 func Detect(file *tiff.File) bool {
-	if !file.BigTIFF() {
-		return false
-	}
 	for _, p := range file.Pages() {
 		xmp, ok := p.XMP()
 		if !ok {

--- a/formats/bif/detection_test.go
+++ b/formats/bif/detection_test.go
@@ -41,18 +41,22 @@ func TestSupportsBIFWithIScanOnLaterIFD(t *testing.T) {
 	}
 }
 
-// TestSupportsRejectsClassicTIFFWithIScan: detection requires BigTIFF
-// per spec §5.1; a classic TIFF whose XMP contains `<iScan` must NOT
-// match. Classic-TIFF iScan files don't exist (the BIF whitepaper
-// mandates BigTIFF) but we double-check the gate.
-func TestSupportsRejectsClassicTIFFWithIScan(t *testing.T) {
+// TestSupportsClassicTIFFWithIScan: a *classic* (non-BigTIFF) TIFF whose XMP
+// contains `<iScan` must match. The BIF whitepaper mandates BigTIFF for the DP
+// generation, but legacy iScan scanners (Coreo/HT, ~2010-2012, BuildVersion
+// 3.x) wrote classic little-endian TIFF — opentile-go's earlier "BigTIFF
+// required" gate wrongly rejected those, so they fell through to the generic-
+// TIFF reader, which renders BIF's serpentine tile order scrambled. Detection
+// now mirrors openslide's `INITIAL_XML_ISCAN = "iScan"` rule: the `<iScan`
+// XMP marker alone is the discriminator (#37).
+func TestSupportsClassicTIFFWithIScan(t *testing.T) {
 	data := buildClassicTIFFWithXMP(t, []byte(`<iScan/>`))
 	f, err := tiff.Open(bytes.NewReader(data), int64(len(data)))
 	if err != nil {
 		t.Fatalf("tiff.Open: %v", err)
 	}
-	if New().Supports(f) {
-		t.Fatal("expected Supports=false on classic TIFF (BigTIFF required)")
+	if !New().Supports(f) {
+		t.Fatal("expected Supports=true on classic-TIFF iScan (legacy Coreo/HT slides are classic TIFF)")
 	}
 }
 


### PR DESCRIPTION
## Summary
Closes #37. Legacy iScan scanners (Coreo/HT, ~2010–2012, XMP `BuildVersion="3.x"`) wrote BIF as **classic** (non-BigTIFF) little-endian TIFF. BIF detection required BigTIFF *in addition* to the `<iScan` XMP marker, so these slides weren't claimed by the BIF reader:
- most fell through to the **generic-TIFF** reader — which reads tiles row-major, while BIF stores them **serpentine + vertically flipped** (`TileOffsets[0]` = bottom-left, odd stage rows right-to-left) → the scrambled **"corrupt BIF"** symptom in viewers (openscope);
- some failed to open at all (`unknown format`).

(ImageScope doesn't read BIF — Aperio format — so "refuses to open" there is expected and separate.)

## Fix
`Detect()` now keys on the `<iScan` XMP marker **alone**, matching openslide's `INITIAL_XML_ISCAN` rule (no BigTIFF requirement). The "classic-TIFF iScan files don't exist" assumption was wrong — legacy iScan predates the DP-generation BIF whitepaper. The reader's serpentine / blank-tile / associated-image machinery is container-agnostic, so it handles classic-TIFF iScan slides once detected.

## Diagnosis evidence
Three real legacy slides (`II*` classic TIFF, `<iScan ... BuildVersion="3.2.0.0">`):

| | before | after |
|---|---|---|
| `1_19.bif` | `generic-tiff`, 4 levels (scrambled) | **`bif`, 7 levels** |
| `AC1.592.bif` | `generic-tiff` (scrambled) | **`bif`, 8 levels** |
| `S12-18199-1A.bif` | `unknown format` | **`bif`, 8 levels** |

After the fix: open + full smallest-level tile-walk (zero errors) + **coherent rendered output** (visually verified — tissue no longer serpentine-scrambled) + associated images decode.

## Test Plan
- [x] `formats/bif.TestSupportsClassicTIFFWithIScan` — synthetic classic-TIFF iScan → supported (flipped from the old "rejects" test; **runs in CI**).
- [x] `TestLegacyClassicTIFFBIF` — skip-if-missing regression over the real legacy slides (format=bif, tile-walk, decoded tile, associated decode). These are **real clinical slides with PHI** (accession-numbered) → local sample set only, **never published**; skips in CI.
- [x] No false positives: full parity + cross-format suite green under `-race` (no existing fixture now mis-detected as BIF).

🤖 Generated with [Claude Code](https://claude.com/claude-code)