### PR TITLE
Release v0.41.3 — legacy classic-TIFF iScan BIF detection (#37)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ upstream references, and retirement audit per milestone.
 
 ## [Unreleased]
 
+## [0.41.3] — 2026-06-15
+
+BIF legacy-slide read fix. No public API changes.
+
 ### Fixed
 
 - **BIF: detect legacy classic-TIFF iScan slides** (#37). Legacy iScan scanners


### PR DESCRIPTION
Stamps the CHANGELOG `## [0.41.3]` section for the patch release covering #37:

- **#37** — BIF detection no longer requires BigTIFF, so legacy classic-TIFF iScan slides (Coreo/HT, ~2010–2012) are read through the BIF reader (serpentine de-scrambled) instead of falling through to generic-TIFF (scrambled) or failing to open.

Patch bump — **no public API changes** (only test functions changed since v0.41.2; `Detect` signature unchanged, behavior-only). After merge, an annotated `v0.41.3` tag triggers the release workflow.