### PR TITLE
Release v0.42.0 — decoder codestream Probe (#41) + BIF synthesized label (#19)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ upstream references, and retirement audit per milestone.
 
 ## [Unreleased]
 
+## [0.42.0] — 2026-06-15
+
+Two additive features — a header-only decoder codestream `Probe` (#41, new
+public `decoder.Prober` API) and a synthesized BIF `label` associated image
+(#19). No breaking changes.
+
 ### Added
 
 - **Decoder codestream `Probe` — header-only codec metadata** (#41). New


### PR DESCRIPTION
Stamps the CHANGELOG `## [0.42.0]` section. **Minor** bump — two additive features since v0.41.3, no breaking changes:

- **#41** — header-only `decoder.Prober` (`Probe(src) (CodestreamInfo, error)`) on jpeg/jpeg2000/htj2k/jpegxl for frame-copy metadata (new public API → minor bump).
- **#19** — BIF synthesized `label` associated image (top 1/3 of the overview), parity with NDPI.

After merge, an annotated `v0.42.0` tag triggers the release workflow (notes from this CHANGELOG section).