### PR TITLE
Release v0.42.1 — rename Prober → CodestreamInspector (#41)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ upstream references, and retirement audit per milestone.
 
 ## [Unreleased]
 
+## [0.42.1] — 2026-06-15
+
+Pre-adoption rename of the v0.42.0 codestream-inspection API (#41). Marked
+breaking for discoverability, but the API was one release old with no consumers.
+
 ### Changed (BREAKING)
 
 - **Renamed the #41 codestream-inspection API** for self-documentation:


### PR DESCRIPTION
Stamps the CHANGELOG `## [0.42.1]` section for the pre-adoption rename of the v0.42.0 codestream-inspection API:

- `decoder.Prober` → `decoder.CodestreamInspector`, method `Probe` → `Inspect` (PR #45). `CodestreamInfo`/`Lossless`/`ColorEncoding` unchanged.

Marked **breaking** for discoverability, but the API was one release (hours) old with **no consumers**. After merge, an annotated `v0.42.1` tag triggers the release workflow.