### PR TITLE
feat(decoder): add CodestreamInfo.ChromaSubsampling to the inspector (#41)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,19 @@ upstream references, and retirement audit per milestone.
 
 ## [Unreleased]
 
+### Added
+
+- **`CodestreamInfo.ChromaSubsampling`** (#41 follow-up, on wsitools feedback).
+  The codestream inspector now reports chroma subsampling (`4:4:4` / `4:2:2` /
+  `4:2:0` / `4:4:0` / `4:1:1`, `none` for grayscale, `unknown` where unavailable),
+  so a frame-copy consumer can distinguish DICOM YBR_FULL_422 (4:2:2) from
+  YBR_FULL (4:4:4) — a dciodvfy conformance distinction — letting wsitools retire
+  both its `jp2kmeta` and `jpegmeta` raw-byte parsers. JPEG reads it from the SOF
+  component sampling factors (`tjDecompressHeader3`, previously discarded);
+  JPEG 2000 / HTJ2K from the SIZ per-component XRsiz/YRsiz (verified: a 4:2:2
+  J2K codestream reports `Subsampling422`); JPEG XL reports
+  `SubsamplingUnknown`. Additive — a new field + `ChromaSubsampling` enum.
+
 ## [0.42.1] — 2026-06-15
 
 Pre-adoption rename of the v0.42.0 codestream-inspection API (#41). Marked

--- a/decoder/codestream.go
+++ b/decoder/codestream.go
@@ -46,6 +46,14 @@ type CodestreamInfo struct {
 	// ColorEncoding is the codec-domain color encoding of the samples.
 	ColorEncoding ColorEncoding
 
+	// ChromaSubsampling is the chroma subsampling of the samples. It matters to
+	// frame-copy consumers that must distinguish, e.g., DICOM YBR_FULL_422
+	// (4:2:2) from YBR_FULL (4:4:4) — a conformance distinction. JPEG reports it
+	// from the SOF component sampling factors; JPEG 2000 / HTJ2K from the SIZ
+	// per-component XRsiz/YRsiz. Grayscale codestreams report SubsamplingNone;
+	// codecs that don't expose it (e.g. JPEG XL) report SubsamplingUnknown.
+	ChromaSubsampling ChromaSubsampling
+
 	// Boxed reports whether src is a boxed container (JP2 / JPH / JXL container)
 	// rather than a raw codestream (J2K / raw JXL). Targets such as DICOM
 	// require a specific encapsulated form (e.g. HTJ2K wants the raw .j2c
@@ -105,6 +113,40 @@ func (c ColorEncoding) String() string {
 		return "YBR_ICT"
 	case ColorYBRRCT:
 		return "YBR_RCT"
+	default:
+		return "unknown"
+	}
+}
+
+// ChromaSubsampling is the chroma subsampling of a codestream's samples,
+// expressed in the conventional J:a:b notation. SubsamplingNone is a
+// single-channel (grayscale) codestream with no chroma to subsample.
+type ChromaSubsampling uint8
+
+const (
+	SubsamplingUnknown ChromaSubsampling = iota
+	SubsamplingNone                      // grayscale / no chroma channels
+	Subsampling444                       // no chroma subsampling
+	Subsampling422                       // 2:1 horizontal
+	Subsampling420                       // 2:1 horizontal + vertical
+	Subsampling440                       // 2:1 vertical
+	Subsampling411                       // 4:1 horizontal
+)
+
+func (s ChromaSubsampling) String() string {
+	switch s {
+	case SubsamplingNone:
+		return "none"
+	case Subsampling444:
+		return "4:4:4"
+	case Subsampling422:
+		return "4:2:2"
+	case Subsampling420:
+		return "4:2:0"
+	case Subsampling440:
+		return "4:4:0"
+	case Subsampling411:
+		return "4:1:1"
 	default:
 		return "unknown"
 	}

--- a/decoder/htj2k/htj2k_inspect_test.go
+++ b/decoder/htj2k/htj2k_inspect_test.go
@@ -25,8 +25,9 @@ func TestHTJ2KInspect(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Inspect: %v", err)
 	}
-	if ci.Components != 3 || ci.BitDepth != 8 || ci.Lossless != decoder.LosslessYes {
-		t.Errorf("htj2k inspect = %+v, want comps=3 depth=8 lossless", ci)
+	if ci.Components != 3 || ci.BitDepth != 8 || ci.Lossless != decoder.LosslessYes ||
+		ci.ChromaSubsampling != decoder.Subsampling444 {
+		t.Errorf("htj2k inspect = %+v, want comps=3 depth=8 lossless 4:4:4", ci)
 	}
 
 	if _, err := p.Inspect([]byte{0xFF, 0xD8}); err == nil { // JPEG SOI, not J2K

--- a/decoder/jpeg/jpeg_cgo.go
+++ b/decoder/jpeg/jpeg_cgo.go
@@ -68,6 +68,22 @@ func (f *factory) Inspect(src []byte) (decoder.CodestreamInfo, error) {
 	default:
 		ci.Components, ci.ColorEncoding = 3, decoder.ColorUnknown
 	}
+	switch subsamp {
+	case C.TJSAMP_444:
+		ci.ChromaSubsampling = decoder.Subsampling444
+	case C.TJSAMP_422:
+		ci.ChromaSubsampling = decoder.Subsampling422
+	case C.TJSAMP_420:
+		ci.ChromaSubsampling = decoder.Subsampling420
+	case C.TJSAMP_440:
+		ci.ChromaSubsampling = decoder.Subsampling440
+	case C.TJSAMP_411:
+		ci.ChromaSubsampling = decoder.Subsampling411
+	case C.TJSAMP_GRAY:
+		ci.ChromaSubsampling = decoder.SubsamplingNone
+	default:
+		ci.ChromaSubsampling = decoder.SubsamplingUnknown
+	}
 	return ci, nil
 }
 

--- a/decoder/jpeg/jpeg_inspect_test.go
+++ b/decoder/jpeg/jpeg_inspect_test.go
@@ -42,12 +42,13 @@ func TestJPEGInspect(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	// image/jpeg encodes YCbCr with 4:2:0 chroma subsampling.
 	if ci.Components != 3 || ci.BitDepth != 8 || ci.Lossless != decoder.LosslessNo ||
-		ci.ColorEncoding != decoder.ColorYCbCr || ci.Boxed {
-		t.Errorf("color JPEG inspect = %+v, want comps=3 depth=8 lossy YCbCr raw", ci)
+		ci.ColorEncoding != decoder.ColorYCbCr || ci.ChromaSubsampling != decoder.Subsampling420 || ci.Boxed {
+		t.Errorf("color JPEG inspect = %+v, want comps=3 depth=8 lossy YCbCr 4:2:0 raw", ci)
 	}
 
-	// Grayscale JPEG.
+	// Grayscale JPEG → no chroma.
 	gray := image.NewGray(image.Rect(0, 0, 16, 16))
 	for i := range gray.Pix {
 		gray.Pix[i] = uint8(i)
@@ -56,8 +57,8 @@ func TestJPEGInspect(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if ci.Components != 1 || ci.ColorEncoding != decoder.ColorGrayscale {
-		t.Errorf("gray JPEG inspect = %+v, want comps=1 grayscale", ci)
+	if ci.Components != 1 || ci.ColorEncoding != decoder.ColorGrayscale || ci.ChromaSubsampling != decoder.SubsamplingNone {
+		t.Errorf("gray JPEG inspect = %+v, want comps=1 grayscale none", ci)
 	}
 
 	// Corrupt input → error.

--- a/decoder/jpeg2000/jp2_inspect_test.go
+++ b/decoder/jpeg2000/jp2_inspect_test.go
@@ -23,12 +23,13 @@ func TestJPEG2000Inspect(t *testing.T) {
 		file       string
 		lossless   decoder.Lossless
 		color      decoder.ColorEncoding
+		chroma     decoder.ChromaSubsampling
 		components int
 	}{
-		// Reversible 5/3 + MCT → YBR_RCT, lossless.
-		{"testdata/lowres_2levels.j2k", decoder.LosslessYes, decoder.ColorYBRRCT, 3},
-		// Irreversible 9/7, no MCT.
-		{"testdata/subsampled_422_256.j2k", decoder.LosslessNo, decoder.ColorRGB, 3},
+		// Reversible 5/3 + MCT → YBR_RCT, lossless, no subsampling.
+		{"testdata/lowres_2levels.j2k", decoder.LosslessYes, decoder.ColorYBRRCT, decoder.Subsampling444, 3},
+		// Irreversible 9/7, no MCT, 4:2:2 chroma (XRsiz=2 on the chroma components).
+		{"testdata/subsampled_422_256.j2k", decoder.LosslessNo, decoder.ColorRGB, decoder.Subsampling422, 3},
 	} {
 		b, err := os.ReadFile(tc.file)
 		if err != nil {
@@ -39,9 +40,9 @@ func TestJPEG2000Inspect(t *testing.T) {
 			t.Fatalf("%s: %v", tc.file, err)
 		}
 		if ci.Components != tc.components || ci.BitDepth != 8 || ci.Lossless != tc.lossless ||
-			ci.ColorEncoding != tc.color || ci.Boxed {
-			t.Errorf("%s inspect = %+v, want comps=%d depth=8 lossless=%s color=%s raw",
-				tc.file, ci, tc.components, tc.lossless, tc.color)
+			ci.ColorEncoding != tc.color || ci.ChromaSubsampling != tc.chroma || ci.Boxed {
+			t.Errorf("%s inspect = %+v, want comps=%d depth=8 lossless=%s color=%s chroma=%s raw",
+				tc.file, ci, tc.components, tc.lossless, tc.color, tc.chroma)
 		}
 	}
 

--- a/decoder/jpegxl/jxl_inspect_test.go
+++ b/decoder/jpegxl/jxl_inspect_test.go
@@ -30,7 +30,7 @@ func TestJPEGXLInspect(t *testing.T) {
 	}
 	// libjxl exposes no header-only lossless flag → LosslessUnknown is expected.
 	if ci.Components != 3 || ci.BitDepth != 8 || ci.Lossless != decoder.LosslessUnknown ||
-		ci.ColorEncoding != decoder.ColorRGB || ci.Boxed {
+		ci.ColorEncoding != decoder.ColorRGB || ci.ChromaSubsampling != decoder.SubsamplingUnknown || ci.Boxed {
 		t.Errorf("jxl inspect = %+v, want comps=3 depth=8 lossless=unknown RGB raw", ci)
 	}
 

--- a/docs/superpowers/specs/2026-06-15-decoder-codestream-probe-design.md
+++ b/docs/superpowers/specs/2026-06-15-decoder-codestream-probe-design.md
@@ -23,11 +23,12 @@ lives on the `Factory` (stateless header parse — no `New()` lifecycle):
 type CodestreamInspector interface { Inspect(src []byte) (CodestreamInfo, error) }
 
 type CodestreamInfo struct {
-    Components    int           // sample/channel count
-    BitDepth      int           // bits per component
-    Lossless      Lossless      // tri-state (see below)
-    ColorEncoding ColorEncoding // Unknown/Grayscale/RGB/YCbCr/YBR_ICT/YBR_RCT
-    Boxed         bool          // boxed container vs raw codestream
+    Components        int               // sample/channel count
+    BitDepth          int               // bits per component
+    Lossless          Lossless          // tri-state (see below)
+    ColorEncoding     ColorEncoding     // Unknown/Grayscale/RGB/YCbCr/YBR_ICT/YBR_RCT
+    ChromaSubsampling ChromaSubsampling // None/4:4:4/4:2:2/4:2:0/4:4:0/4:1:1 (added post-v0.42.1)
+    Boxed             bool              // boxed container vs raw codestream
 }
 
 type Lossless uint8       // LosslessUnknown | LosslessYes | LosslessNo
@@ -57,6 +58,13 @@ if p, ok := f.(decoder.CodestreamInspector); ok { info, err := p.Inspect(src) }
 - **Color encoding is codec-domain** (how samples are stored, what a frame-copy
   preserves), not display intent: JP2K MCT → YBR_RCT (reversible) / YBR_ICT
   (irreversible); no MCT → RGB (or grayscale/sYCC from a JP2 `colr` box).
+- **Chroma subsampling** (added after v0.42.1, on wsitools feedback) lets a
+  consumer distinguish DICOM YBR_FULL_422 (4:2:2) from YBR_FULL (4:4:4) — a
+  dciodvfy conformance distinction — so wsitools' `jpegmeta` (and `jp2kmeta`)
+  raw-byte parsers retire fully. JPEG reads it from the SOF component sampling
+  factors (already returned by `tjDecompressHeader3`, previously discarded);
+  J2K/HTJ2K from the SIZ per-component XRsiz/YRsiz; JPEG XL reports
+  `SubsamplingUnknown`. Grayscale codestreams report `SubsamplingNone`.
 
 ## Per-codec implementation
 

--- a/internal/j2kheader/j2kheader.go
+++ b/internal/j2kheader/j2kheader.go
@@ -30,6 +30,11 @@ type Info struct {
 	// EnumColorspace is the JP2 'colr' box enumerated colorspace when present
 	// on a boxed input (16 = sRGB, 17 = grayscale, 18 = sYCC); -1 otherwise.
 	EnumColorspace int
+
+	// XRsiz / YRsiz are the per-component horizontal / vertical sub-sampling
+	// factors from SIZ (component 0 = luma, typically 1/1). Used to derive
+	// chroma subsampling (4:2:2 vs 4:4:4, etc.).
+	XRsiz, YRsiz []int
 }
 
 // CodestreamInfo maps the codec-agnostic J2K header facts to the
@@ -40,7 +45,12 @@ type Info struct {
 // it, three components are RGB unless a JP2 'colr' box declares an enumerated
 // grayscale / sYCC space.
 func (h Info) CodestreamInfo() decoder.CodestreamInfo {
-	ci := decoder.CodestreamInfo{Components: h.Components, BitDepth: h.BitDepth, Boxed: h.Boxed}
+	ci := decoder.CodestreamInfo{
+		Components:        h.Components,
+		BitDepth:          h.BitDepth,
+		Boxed:             h.Boxed,
+		ChromaSubsampling: h.chromaSubsampling(),
+	}
 	if h.Reversible {
 		ci.Lossless = decoder.LosslessYes
 	} else {
@@ -64,6 +74,31 @@ func (h Info) CodestreamInfo() decoder.CodestreamInfo {
 		}
 	}
 	return ci
+}
+
+// chromaSubsampling derives the chroma subsampling from the SIZ per-component
+// sub-sampling factors (component 1 = first chroma, relative to luma's 1/1).
+func (h Info) chromaSubsampling() decoder.ChromaSubsampling {
+	if h.Components == 1 {
+		return decoder.SubsamplingNone
+	}
+	if h.Components < 3 || len(h.XRsiz) < 2 || len(h.YRsiz) < 2 {
+		return decoder.SubsamplingUnknown
+	}
+	switch hx, vy := h.XRsiz[1], h.YRsiz[1]; {
+	case hx == 1 && vy == 1:
+		return decoder.Subsampling444
+	case hx == 2 && vy == 1:
+		return decoder.Subsampling422
+	case hx == 2 && vy == 2:
+		return decoder.Subsampling420
+	case hx == 1 && vy == 2:
+		return decoder.Subsampling440
+	case hx == 4 && vy == 1:
+		return decoder.Subsampling411
+	default:
+		return decoder.SubsamplingUnknown
+	}
 }
 
 // J2K marker codes (big-endian, 0xFFxx).
@@ -96,12 +131,14 @@ func Parse(src []byte) (Info, error) {
 		return Info{}, ErrNotJ2K
 	}
 
-	comps, bitDepth, sizEnd, err := parseSIZ(cs)
+	comps, bitDepth, xr, yr, sizEnd, err := parseSIZ(cs)
 	if err != nil {
 		return Info{}, err
 	}
 	info.Components = comps
 	info.BitDepth = bitDepth
+	info.XRsiz = xr
+	info.YRsiz = yr
 
 	mct, reversible, ok := findCOD(cs, sizEnd)
 	if !ok {
@@ -115,29 +152,36 @@ func Parse(src []byte) (Info, error) {
 // parseSIZ reads the SIZ marker (which must immediately follow SOC) and returns
 // the component count, component-0 bit depth, and the offset just past the SIZ
 // segment (where main-header marker walking resumes).
-func parseSIZ(cs []byte) (components, bitDepth, sizEnd int, err error) {
+func parseSIZ(cs []byte) (components, bitDepth int, xr, yr []int, sizEnd int, err error) {
 	// cs[0:2] = SOC. SIZ marker begins at cs[2].
 	if len(cs) < 4 || cs[2] != 0xFF || cs[3] != mrkSIZ {
-		return 0, 0, 0, ErrNotJ2K
+		return 0, 0, nil, nil, 0, ErrNotJ2K
 	}
 	siz := 2 // SIZ marker offset
 	if len(cs) < siz+40 {
-		return 0, 0, 0, ErrNotJ2K
+		return 0, 0, nil, nil, 0, ErrNotJ2K
 	}
 	lsiz := int(binary.BigEndian.Uint16(cs[siz+2 : siz+4]))
 	// Csiz (component count) sits 38 bytes into the SIZ marker (after FF51,
 	// Lsiz, Rsiz, and the eight 4-byte image/tile geometry fields).
 	csiz := int(binary.BigEndian.Uint16(cs[siz+38 : siz+40]))
 	if csiz < 1 {
-		return 0, 0, 0, ErrNotJ2K
+		return 0, 0, nil, nil, 0, ErrNotJ2K
 	}
-	// Ssiz of component 0 immediately follows Csiz.
-	if len(cs) < siz+41 {
-		return 0, 0, 0, ErrNotJ2K
+	// Per-component triplets [Ssiz, XRsiz, YRsiz] follow Csiz, starting at
+	// siz+40 (3 bytes each).
+	if len(cs) < siz+40+3*csiz {
+		return 0, 0, nil, nil, 0, ErrNotJ2K
 	}
-	ssiz0 := cs[siz+40]
-	bitDepth = int(ssiz0&0x7F) + 1
-	return csiz, bitDepth, siz + 2 + lsiz, nil
+	xr = make([]int, csiz)
+	yr = make([]int, csiz)
+	for i := 0; i < csiz; i++ {
+		base := siz + 40 + 3*i
+		xr[i] = int(cs[base+1])
+		yr[i] = int(cs[base+2])
+	}
+	bitDepth = int(cs[siz+40]&0x7F) + 1 // Ssiz of component 0
+	return csiz, bitDepth, xr, yr, siz + 2 + lsiz, nil
 }
 
 // findCOD walks the main-header markers from offset start until it finds COD,

--- a/internal/j2kheader/j2kheader_test.go
+++ b/internal/j2kheader/j2kheader_test.go
@@ -3,6 +3,8 @@ package j2kheader
 import (
 	"encoding/binary"
 	"testing"
+
+	"github.com/wsilabs/opentile-go/decoder"
 )
 
 // buildCodestream assembles a minimal raw J2K main header: SOC + SIZ + COD.
@@ -50,6 +52,10 @@ func TestParseRawReversibleRGB(t *testing.T) {
 	}
 	if got.Components != 3 || got.BitDepth != 8 || !got.Reversible || !got.MCT || got.Boxed {
 		t.Fatalf("got %+v, want comps=3 depth=8 reversible MCT raw", got)
+	}
+	// All components XRsiz=YRsiz=1 (buildCodestream default) → 4:4:4.
+	if cs := got.CodestreamInfo().ChromaSubsampling; cs != decoder.Subsampling444 {
+		t.Errorf("ChromaSubsampling = %s, want 4:4:4", cs)
 	}
 }
 


### PR DESCRIPTION
## Summary
Follow-up to #41 on **wsitools feedback**. The inspector's `ColorEncoding`+`Lossless`+`Components` already reproduce `PhotometricJP2K` exactly (so wsitools' `jp2kmeta` retires), but the JPEG path lacked **chroma subsampling** — which `jpegmeta` needs to pick DICOM **YBR_FULL_422 (4:2:2)** vs **YBR_FULL (4:4:4)**, a dciodvfy conformance distinction. Without it, `jpegmeta` couldn't fully retire.

The JPEG inspector already read `subsamp` from `tjDecompressHeader3` and **discarded** it — so this is nearly free. Adds `CodestreamInfo.ChromaSubsampling` + a `ChromaSubsampling` enum (`none`/`4:4:4`/`4:2:2`/`4:2:0`/`4:4:0`/`4:1:1`/`unknown`):

| codec | source |
|---|---|
| jpeg | `tjDecompressHeader3` `subsamp` (TJSAMP_*) |
| jpeg2000 + htj2k | `internal/j2kheader` now reads SIZ per-component XRsiz/YRsiz and derives it |
| jpegxl | `SubsamplingUnknown` (libjxl doesn't expose it header-only) |
| grayscale | `SubsamplingNone` |

**Result: wsitools retires both `jp2kmeta` and `jpegmeta`.**

## Verification
- J2K: `subsampled_422_256.j2k` → **4:2:2**, `lowres_2levels.j2k` → **4:4:4** (real testdata).
- JPEG: Go `image/jpeg` → YCbCr 4:2:0; real Aperio **CMU-1 → RGB 4:4:4** (APP14 raw-RGB), **scan_617 → YCbCr 4:2:0**.
- DICOM acceptance: 3DHISTECH HTJ2K + JP2K frames → RGB 4:4:4.
- Per-codec inspect tests assert the new field; decoder + j2kheader green under `-race`; build matrix (full/nojp2k/nohtj2k/nojxl/nocgo) green.

**Additive** (new field + enum) → minor bump on release.

## On the other wsitools findings
- **JXL `LosslessUnknown` → TS .112 fallback**: correct given libjxl's `JxlBasicInfo` has no lossless flag; nothing opentile-go can do header-only. (A JXL fixture does exist now: `decoder/jpegxl/testdata/sample_tile.jxl` + `sample_files/generic-tiff/jxl-out.tiff`.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)