### PR TITLE
Release v0.43.0 — inspector ChromaSubsampling (#41)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ upstream references, and retirement audit per milestone.
 
 ## [Unreleased]
 
+## [0.43.0] — 2026-06-15
+
+Additive: the codestream inspector (#41) gains `CodestreamInfo.ChromaSubsampling`.
+
 ### Added
 
 - **`CodestreamInfo.ChromaSubsampling`** (#41 follow-up, on wsitools feedback).


### PR DESCRIPTION
Stamps the CHANGELOG `## [0.43.0]` section. **Minor** bump — additive `CodestreamInfo.ChromaSubsampling` (+ `ChromaSubsampling` enum), which lets wsitools retire both `jp2kmeta` and `jpegmeta` (DICOM YBR_FULL_422 vs YBR_FULL). No breaking changes.

After merge, an annotated `v0.43.0` tag triggers the release workflow.