### PR TITLE
Release v0.44.0 — WebP scaled decode (#11)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ upstream references, and retirement audit per milestone.
 
 ## [Unreleased]
 
+## [0.44.0] — 2026-06-16
+
+Additive: WebP gains codec-domain scaled decode (#11), completing the feasible
+codec set under the `DecodeOptions.Scale` contract.
+
 ### Added
 
 - **WebP codec-domain scaled decode** (#11). The webp decoder now honors


### PR DESCRIPTION
Stamps the CHANGELOG `## [0.44.0]` section. **Minor** bump — additive WebP codec-domain scaled decode (#11, closing the feasible codec set under `DecodeOptions.Scale`). No breaking changes. After merge, an annotated `v0.44.0` tag triggers the release workflow.