### PR TITLE
release: v0.44.1 — DICOM dep → WSILabs/dicom fork

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ upstream references, and retirement audit per milestone.
 
 ## [Unreleased]
 
+## [0.44.1] — 2026-06-16
+
+Maintenance: the DICOM metadata parser moves to the maintained `WSILabs/dicom`
+fork, retiring the HTJ2K SIGSEGV workaround. Transitive dependency change only —
+no opentile-go public API or behavior change.
+
 ### Changed
 
 - **DICOM dependency migrated to `github.com/WSILabs/dicom`** (a maintained


### PR DESCRIPTION
Stamps CHANGELOG `[0.44.1]`. Patch release for the maintenance change already on main (#51): the DICOM metadata parser now uses the maintained pure-Go `github.com/WSILabs/dicom` fork (was `suyashkumar/dicom`), and the HTJ2K transfer-syntax SIGSEGV workaround is retired. Transitive-dependency change only — no public API or behavior change.

After merge, an annotated `v0.44.1` tag is cut from green main; `release.yml` publishes the release from the `## [0.44.1]` section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)