### PR TITLE
fix(validate): evaluate MPP at slide level, not per-Level (#55)

### DIFF
--- a/validate.go
+++ b/validate.go
@@ -40,9 +40,9 @@ func (s Severity) String() string {
 type CheckCode string
 
 const (
-	CheckUnopenable          CheckCode = "unopenable"
-	CheckOffsetsOutOfBounds  CheckCode = "offsets-out-of-bounds"
-	CheckTileGridMismatch    CheckCode = "tile-grid-mismatch"
+	CheckUnopenable         CheckCode = "unopenable"
+	CheckOffsetsOutOfBounds CheckCode = "offsets-out-of-bounds"
+	CheckTileGridMismatch   CheckCode = "tile-grid-mismatch"
 	// CheckNonConformantFormat is reserved: no reader emits it in v1 (COG-WSI
 	// conformance is enforced fatally at Open). Kept for future per-format soft checks.
 	CheckNonConformantFormat CheckCode = "non-conformant-format"
@@ -253,9 +253,13 @@ func validateOpened(open func() (*Slide, error), opts ...ValidateOption) (*Repor
 func (s *Slide) Validate(opts ...ValidateOption) *Report {
 	p := newProbe(s.size)
 	// Layer 1: format-agnostic geometry checks over every pyramid's levels.
+	// MPP is a slide-level property; several readers expose it only via
+	// Metadata.MPP (not per-level Level.MPP), so treat it as the source of
+	// truth for the missing-metadata check (GH #55).
+	slideHasMPP := !s.r.Metadata().MPP.IsZero()
 	s.ensurePyramids()
 	for pi := range s.pyramids {
-		checkLevelGeometry(p, s.pyramids[pi].Index, s.pyramids[pi].Levels)
+		checkLevelGeometry(p, s.pyramids[pi].Index, s.pyramids[pi].Levels, slideHasMPP)
 	}
 	// Layer 2: per-reader hook, if the reader implements Validator.
 	if v, ok := validatorOf(s); ok {
@@ -266,8 +270,18 @@ func (s *Slide) Validate(opts ...ValidateOption) *Report {
 
 // checkLevelGeometry runs the format-agnostic Tier-1 checks for one pyramid's
 // levels: grid math, monotone downsampling, and MPP presence.
-func checkLevelGeometry(p *ValidationProbe, pyramid int, levels []Level) {
+// checkLevelGeometry runs the per-pyramid structural checks. slideHasMPP is
+// true when the slide carries an MPP at the slide level (Metadata.MPP); MPP is
+// fundamentally a slide property, so the missing-metadata check is evaluated
+// once per pyramid against the slide-level MPP OR any per-level MPP, not per
+// level — several readers populate only the slide-level Metadata.MPP and leave
+// Level.MPP zero, which must not be reported as missing (GH #55).
+func checkLevelGeometry(p *ValidationProbe, pyramid int, levels []Level, slideHasMPP bool) {
+	pyramidHasMPP := slideHasMPP
 	for _, l := range levels {
+		if !l.MPP.IsZero() {
+			pyramidHasMPP = true
+		}
 		if l.Size.W <= 0 || l.Size.H <= 0 ||
 			l.TileSize.W <= 0 || l.TileSize.H <= 0 {
 			p.Flag(CheckTileGridMismatch, pyramid, l.Index,
@@ -282,10 +296,10 @@ func checkLevelGeometry(p *ValidationProbe, pyramid int, levels []Level) {
 				fmt.Sprintf("level %d grid %dx%d != ceil(size/tile) %dx%d",
 					l.Index, l.Grid.W, l.Grid.H, wantW, wantH))
 		}
-		if l.MPP.IsZero() {
-			p.Flag(CheckMissingMetadata, pyramid, l.Index,
-				fmt.Sprintf("level %d has no MPP (microns-per-pixel) metadata", l.Index))
-		}
+	}
+	if !pyramidHasMPP {
+		p.Flag(CheckMissingMetadata, pyramid, -1,
+			"no MPP (microns-per-pixel) metadata at the slide or any level")
 	}
 	for i := 1; i < len(levels); i++ {
 		if levels[i].Size.W > levels[i-1].Size.W ||

--- a/validate_corpus_test.go
+++ b/validate_corpus_test.go
@@ -36,6 +36,30 @@ func TestValidateNDPIFixtureOK(t *testing.T) {
 	}
 }
 
+// TestValidateNDPINoMPPFalsePositive guards GH #55: CMU-1.ndpi carries MPP at
+// the slide level (Metadata.MPP) but not per-level (Level.MPP). Validate must
+// NOT emit a missing-metadata finding for it.
+func TestValidateNDPINoMPPFalsePositive(t *testing.T) {
+	p := filepath.Join(corpusDir(t), "ndpi", "CMU-1.ndpi")
+	if _, err := os.Stat(p); err != nil {
+		t.Skipf("fixture absent: %v", err)
+	}
+	s, err := opentile.OpenFile(p)
+	if err != nil {
+		t.Fatalf("OpenFile: %v", err)
+	}
+	defer s.Close()
+	if s.Metadata().MPP.IsZero() {
+		t.Skip("fixture has no slide-level MPP; nothing to guard")
+	}
+	rep := s.Validate()
+	for _, f := range rep.Findings {
+		if f.Code == opentile.CheckMissingMetadata {
+			t.Fatalf("missing-metadata false positive despite slide MPP %v: %+v", s.Metadata().MPP, f)
+		}
+	}
+}
+
 func TestValidatePhilipsTIFFFixtureOK(t *testing.T) {
 	p := filepath.Join(corpusDir(t), "philips-tiff", "Philips-1.tiff")
 	if _, err := os.Stat(p); err != nil {

--- a/validate_test.go
+++ b/validate_test.go
@@ -146,10 +146,52 @@ func TestEngineGridMismatchFromLevels(t *testing.T) {
 		MPP:      MPP{X: 0.25, Y: 0.25},
 	}}
 	p := newProbe(0)
-	checkLevelGeometry(p, 0, lvls)
+	checkLevelGeometry(p, 0, lvls, false)
 	got := p.findings()
 	if len(got) != 1 || got[0].Code != CheckTileGridMismatch {
 		t.Fatalf("findings = %+v, want one CheckTileGridMismatch", got)
+	}
+}
+
+// TestEngineMPPSlideLevelSuppresses: a level with zero Level.MPP must NOT
+// produce a missing-metadata finding when the slide carries MPP at the slide
+// level (Metadata.MPP). Guards the GH #55 false-positive on readers that
+// populate only the slide-level MPP (ndpi/leica-scn/dicom/generic-tiff/...).
+func TestEngineMPPSlideLevelSuppresses(t *testing.T) {
+	lvls := []Level{{
+		Index: 0, Size: Size{W: 512, H: 512}, TileSize: Size{W: 256, H: 256}, Grid: Size{W: 2, H: 2},
+		// Level.MPP intentionally zero.
+	}}
+	p := newProbe(0)
+	checkLevelGeometry(p, 0, lvls, true /* slide has MPP */)
+	for _, f := range p.findings() {
+		if f.Code == CheckMissingMetadata {
+			t.Fatalf("missing-metadata flagged despite slide-level MPP: %+v", f)
+		}
+	}
+}
+
+// TestEngineMPPMissingEverywhere: when neither the slide nor any level carries
+// MPP, exactly one missing-metadata finding fires, once per pyramid (locus -1),
+// not once per level.
+func TestEngineMPPMissingEverywhere(t *testing.T) {
+	lvls := []Level{
+		{Index: 0, Size: Size{W: 512, H: 512}, TileSize: Size{W: 256, H: 256}, Grid: Size{W: 2, H: 2}},
+		{Index: 1, Size: Size{W: 256, H: 256}, TileSize: Size{W: 256, H: 256}, Grid: Size{W: 1, H: 1}},
+	}
+	p := newProbe(0)
+	checkLevelGeometry(p, 0, lvls, false /* no slide MPP */)
+	var mm []Finding
+	for _, f := range p.findings() {
+		if f.Code == CheckMissingMetadata {
+			mm = append(mm, f)
+		}
+	}
+	if len(mm) != 1 {
+		t.Fatalf("want exactly one missing-metadata finding, got %d: %+v", len(mm), mm)
+	}
+	if mm[0].Level != -1 {
+		t.Fatalf("missing-metadata locus level = %d, want -1 (per-pyramid)", mm[0].Level)
 	}
 }
 
@@ -159,7 +201,7 @@ func TestEngineInconsistentPyramid(t *testing.T) {
 		{Index: 1, Size: Size{W: 1024, H: 1024}, TileSize: Size{W: 256, H: 256}, Grid: Size{W: 4, H: 4}},
 	}
 	p := newProbe(0)
-	checkLevelGeometry(p, 0, lvls)
+	checkLevelGeometry(p, 0, lvls, true)
 	found := false
 	for _, f := range p.findings() {
 		if f.Code == CheckInconsistentPyramid {


### PR DESCRIPTION
Fixes #55.

## Problem
`Validate`'s `missing-metadata` check tested `Level.MPP` per level, so it fired on **every level** of ndpi, leica-scn, dicom, cog-wsi/generic-tiff, ife, and szi — formats whose readers populate the slide-level `Metadata.MPP` but leave per-level `Level.MPP` zero. A downstream 60-slide-corpus sweep found this single warning was the only finding on the vast majority of well-formed slides, making the category noise and a "warnings: 0" gate impractical.

## Fix (issue's Option 2 — the validation question is slide-level)
MPP is a slide property. The check now consults the slide-level `Metadata.MPP` (or any per-level `Level.MPP`) and emits **at most one** `missing-metadata` finding per pyramid (locus `-1`), only when the slide carries no MPP anywhere. A genuinely resolution-less slide (e.g. a bare generic TIFF) still flags, so the warning stays meaningful.

Chose Option 2 over Option 1 (propagate `Level.MPP` to the 6 lagging readers) because the per-level MPP convention isn't uniform (BIF scales `baseMPP * 2^level`; others use per-level metadata), so populating it correctly per format is a separate, riskier data-model change. Left as a noted follow-up.

## Tests
- New `TestEngineMPPSlideLevelSuppresses` (zero `Level.MPP` + slide MPP → no finding) and `TestEngineMPPMissingEverywhere` (no MPP anywhere → exactly one finding at locus -1).
- New corpus guard `TestValidateNDPINoMPPFalsePositive` (CMU-1.ndpi: slide MPP present, no `missing-metadata` finding).
- Full suite green under `-race`; `nocgo` build unaffected (validate stays decode-free).

## Test plan
- [ ] CI green (mac+linux)

🤖 Generated with [Claude Code](https://claude.com/claude-code)