### PR TITLE
feat: RenderThumbnail + RenderMacro — rendered slide-preview APIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,12 @@ upstream references, and retirement audit per milestone.
   upscales past L0; best-level-sourced + Lanczos-resampled; for BIF the render is
   correctly stitched. It is a *rendered* image — distinct from the embedded
   `AssociatedThumbnail`/`AssociatedOverview` on `AssociatedImages()`. Additive.
+- **`RenderMacro`** — `Slide.RenderMacro(bounds Size, opts...)` synthesizes a
+  macro-style orientation image: a slide-shaped canvas (the non-label scan area,
+  ~50×25 mm) with the whole-slide tissue composited at its **true physical size**
+  (from `Metadata.MPP`, falling back to `10/Magnification` — 40×→0.25, 20×→0.5;
+  error if neither) and centred. For slides that don't embed a macro/overview.
+  Centred only (true on-slide position is a future enhancement). Additive.
 
 ## [0.46.0] — 2026-06-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ The single source of truth for "what was deferred and why" is
 front-page summary; the deferred file has the full reasoning,
 upstream references, and retirement audit per milestone.
 
+## [Unreleased]
+
+### Added
+
+- **`RenderThumbnail`** — `Slide.RenderThumbnail(bounds Size, opts...)` and
+  `Pyramid.RenderThumbnail(...)` render a whole-slide thumbnail/overview from the
+  image pyramid (a thin, aspect-preserving convenience over `ReadRegionScaled`).
+  A zero axis in `bounds` is unconstrained, so one `Size` expresses fit-box
+  (`{256,256}`), fit-width (`{256,0}`), and fit-height (`{0,256}`). Never
+  upscales past L0; best-level-sourced + Lanczos-resampled; for BIF the render is
+  correctly stitched. It is a *rendered* image — distinct from the embedded
+  `AssociatedThumbnail`/`AssociatedOverview` on `AssociatedImages()`. Additive.
+
 ## [0.46.0] — 2026-06-18
 
 BIF overlap-aware tile stitching — DP-generation (#60) and legacy iScan (#63).

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ It began as a Go port of the Python [opentile](https://github.com/imi-bigpicture
 **What it does:**
 
 - **Raw tile extraction** — `level.Tile(x, y)` returns the compressed bitstream exactly as stored on disk. Pure Go, no cgo — the zero-copy fast path for tile servers and transcoders.
-- **Decoded pixels** — `ReadRegion` (arbitrary regions), `DecodedTile` (single tiles), and `ReadRegionScaled` (downsampled output) return `*decoder.Image`, via cgo codec decoders (JPEG, JPEG 2000, HTJ2K, WebP, AVIF, JPEG XL).
+- **Decoded pixels** — `ReadRegion` (arbitrary regions), `DecodedTile` (single tiles), `ReadRegionScaled` (downsampled output), and `RenderThumbnail` (whole-slide thumbnail/overview) return `*decoder.Image`, via cgo codec decoders (JPEG, JPEG 2000, HTJ2K, WebP, AVIF, JPEG XL).
 - **Scaled strips / DZI** — `ScaledStrips`, a libvips-style whole-slide region iterator with **byte-bounded** peak memory, for Deep Zoom / tile-pyramid generation.
 - **11 formats, auto-detected** — Aperio SVS, Hamamatsu NDPI, Philips TIFF, OME-TIFF, Ventana BIF, Leica SCN, generic tiled TIFF, COG-WSI, [Iris IFE](https://github.com/IrisDigitalPathology/Iris-File-Extension), [SZI](https://github.com/smartinmedia/SZI-Format), and multi-file **DICOM WSI**.
 - **Associated images & metadata** — label / overview / thumbnail / macro, MPP, magnification, vendor properties, and raw per-level / per-image **TIFF-tag** access.
@@ -179,15 +179,27 @@ img, err := base.ReadRegion(opentile.Region{
     Size:   opentile.Size{W: w, H: h},
 })
 
-// An L0 region scaled to an explicit output size (e.g. a thumbnail
-// of the whole slide). IDCT-time downscale + resample under the hood.
+// An L0 region scaled to an explicit output size. IDCT-time downscale
+// + resample under the hood.
 l0 := t.Levels()[0]
 pyr := t.Pyramid(0)
-thumb, err := pyr.ReadRegionScaled(
+region, err := pyr.ReadRegionScaled(
     opentile.Region{Size: l0.Size}, // full L0 extent
     opentile.Size{W: 1024, H: 1024},
 )
+
+// A whole-slide thumbnail/overview, rendered from the pyramid (a thin,
+// aspect-preserving convenience over ReadRegionScaled). A zero axis is
+// unconstrained, so one Size expresses fit-box / fit-width / fit-height:
+thumb, err := t.RenderThumbnail(opentile.Size{W: 256, H: 256}) // fit inside 256×256
+_, _ = t.RenderThumbnail(opentile.Size{W: 512})                // fit-width:  width 512, height from aspect
+_, _ = t.RenderThumbnail(opentile.Size{H: 512})                // fit-height: height 512, width from aspect
 ```
+
+`RenderThumbnail` always renders from the image pyramid (for BIF it is
+correctly stitched) and never upscales past L0. It is **not** the
+embedded thumbnail/overview — for the scanner's own associated images,
+use `s.AssociatedImages()`.
 
 For whole-slide scaled output that is too large to hold in memory at
 once — DZI/deep-zoom builders, libvips-style pipelines — iterate it in

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ It began as a Go port of the Python [opentile](https://github.com/imi-bigpicture
 **What it does:**
 
 - **Raw tile extraction** — `level.Tile(x, y)` returns the compressed bitstream exactly as stored on disk. Pure Go, no cgo — the zero-copy fast path for tile servers and transcoders.
-- **Decoded pixels** — `ReadRegion` (arbitrary regions), `DecodedTile` (single tiles), `ReadRegionScaled` (downsampled output), and `RenderThumbnail` (whole-slide thumbnail/overview) return `*decoder.Image`, via cgo codec decoders (JPEG, JPEG 2000, HTJ2K, WebP, AVIF, JPEG XL).
+- **Decoded pixels** — `ReadRegion` (arbitrary regions), `DecodedTile` (single tiles), `ReadRegionScaled` (downsampled output), `RenderThumbnail` (whole-slide thumbnail/overview), and `RenderMacro` (synthesized macro at true physical scale) return `*decoder.Image`, via cgo codec decoders (JPEG, JPEG 2000, HTJ2K, WebP, AVIF, JPEG XL).
 - **Scaled strips / DZI** — `ScaledStrips`, a libvips-style whole-slide region iterator with **byte-bounded** peak memory, for Deep Zoom / tile-pyramid generation.
 - **11 formats, auto-detected** — Aperio SVS, Hamamatsu NDPI, Philips TIFF, OME-TIFF, Ventana BIF, Leica SCN, generic tiled TIFF, COG-WSI, [Iris IFE](https://github.com/IrisDigitalPathology/Iris-File-Extension), [SZI](https://github.com/smartinmedia/SZI-Format), and multi-file **DICOM WSI**.
 - **Associated images & metadata** — label / overview / thumbnail / macro, MPP, magnification, vendor properties, and raw per-level / per-image **TIFF-tag** access.
@@ -200,6 +200,13 @@ _, _ = t.RenderThumbnail(opentile.Size{H: 512})                // fit-height: he
 correctly stitched) and never upscales past L0. It is **not** the
 embedded thumbnail/overview — for the scanner's own associated images,
 use `s.AssociatedImages()`.
+
+```go
+// A synthesized macro: the tissue composited at its TRUE physical size
+// (via MPP, or 10/objective-mag) and centred on a slide-shaped canvas —
+// a macro-style orientation image for slides that don't embed one.
+macro, err := s.RenderMacro(opentile.Size{W: 600}) // 600×300 slide canvas
+```
 
 For whole-slide scaled output that is too large to hold in memory at
 once — DZI/deep-zoom builders, libvips-style pipelines — iterate it in

--- a/docs/superpowers/specs/2026-06-18-render-thumbnail-design.md
+++ b/docs/superpowers/specs/2026-06-18-render-thumbnail-design.md
@@ -1,0 +1,108 @@
+# `RenderThumbnail` — rendered full-slide thumbnail/overview API — design
+
+**Status:** design / approved-to-implement
+**Date:** 2026-06-18
+
+---
+
+## 0. Motivation
+
+opentile-go exposes embedded associated images (`AssociatedImages()` →
+label / overview / thumbnail / macro, *when present*) but never **generates** a
+thumbnail/overview for a slide that lacks one. Consumers (a viewer's slide
+gallery; a navigational minimap/overview) need a small whole-slide image
+regardless of whether the file embeds one. Today that requires
+`Pyramid.ReadRegionScaled(fullL0Region, targetSize)` — which works, but the
+caller must read L0's size, pick the longer axis, and compute an
+aspect-preserving target, which is easy to get wrong on non-square slides.
+
+`RenderThumbnail` is a thin, discoverable convenience over `ReadRegionScaled`
+that owns the fit math.
+
+## 1. API
+
+```go
+func (p *Pyramid) RenderThumbnail(bounds Size, opts ...DecodeOption) (*decoder.Image, error)
+func (s *Slide)   RenderThumbnail(bounds Size, opts ...DecodeOption) (*decoder.Image, error) // delegates to Pyramid(0)
+```
+
+**Sizing — `bounds Size`, where a zero axis means "unconstrained" (derive from
+the slide aspect):** (the ImageMagick `256x` / `x256` / `256x256` convention)
+
+| `bounds` | result |
+|---|---|
+| `{W:256, H:256}` | largest aspect-preserved image fitting **inside** 256×256 (**fit-box**) |
+| `{W:256, H:0}`   | **fit-width** — width 256, height from aspect |
+| `{W:0, H:256}`   | **fit-height** — height 256, width from aspect |
+| `{W:0, H:0}`     | error — must constrain ≥1 axis |
+
+One `Size` parameter expresses fit-width, fit-height, and fit-box with no
+separate mode enum. (Exact / non-aspect / stretched-to-box is intentionally NOT
+offered — that is already `ReadRegionScaled(fullL0, exactSize)`.)
+
+## 2. Behavior
+
+- **Always renders from the pyramid.** It does NOT fall back to an embedded
+  `AssociatedThumbnail` / `AssociatedOverview` — those remain on
+  `AssociatedImages()`. Predictable: every slide yields a uniformly-rendered
+  tissue-extent thumbnail (good for a gallery). Doc'd clearly.
+- **Aspect-preserving, never upscales beyond L0.** If `bounds` exceeds L0, the
+  scale is clamped to 1.0 (target = L0 extent). A thumbnail never enlarges.
+- **For BIF the render is correctly stitched** (free from v0.46.0 — it goes
+  through the layout-aware `ReadRegionScaled`).
+- **Best-level sourced + Lanczos-resampled** — inherited from `ReadRegionScaled`
+  (reads the smallest pyramid level that satisfies the downsample, so memory is
+  bounded even for huge slides; small thumbnails read a tiny top level).
+- `opts` pass through (`WithFormat` for RGB/RGBA, etc.). Requires a registered
+  decoder for L0's compression (same as `ReadRegionScaled`).
+- Output dims are exactly the computed target (`thumbnailTargetSize`).
+
+## 3. Implementation
+
+A new file `thumbnail.go` (package `opentile`):
+
+```go
+// thumbnailTargetSize computes the aspect-preserving output size for fitting an
+// l0 (W×H) image into bounds, where a zero (or negative) axis in bounds is
+// unconstrained. Scale is capped at 1.0 (never upscale). Each axis floors at 1.
+func thumbnailTargetSize(l0, bounds Size) (Size, error)
+```
+
+`Pyramid.RenderThumbnail`:
+1. `l0 := p.Level(0)` (propagate its error).
+2. `out, err := thumbnailTargetSize(l0.Size, bounds)`.
+3. `return p.slide.imageReadRegionScaled(p.Index, Region{Origin:{0,0}, Size: l0.Size}, out, opts...)`.
+
+`Slide.RenderThumbnail`: `p := s.Pyramid(0); if p == nil { return nil, ErrImageIndexOutOfRange }; return p.RenderThumbnail(bounds, opts...)`.
+
+New error (or reuse): `bounds` constrains neither axis → a descriptive error
+(`fmt.Errorf`), since no existing sentinel fits. Empty pyramid / level-0 errors
+propagate from `Level(0)`.
+
+## 4. Testing
+
+- **Fixture-free unit tests** (`thumbnail_test.go`, CI-safe) on
+  `thumbnailTargetSize`: fit-box (portrait + landscape, each axis binding),
+  fit-width, fit-height, no-upscale clamp (bounds > L0 → L0), both-zero error,
+  square slide, 1px-floor for extreme downscale.
+- **Fixture-gated integration test**: open `CMU-1-Small-Region.svs`, call
+  `s.RenderThumbnail(Size{W:256,H:256})`, assert output ≤ 256 on both axes, the
+  binding axis ≈ 256, aspect preserved within ±1px, and the image is not
+  entirely white. Plus a fit-width and fit-height case. Skips without
+  `OPENTILE_TESTDIR`.
+
+## 5. Docs
+
+- README: add `RenderThumbnail` to the API surface / a short usage snippet,
+  noting rendered-vs-embedded.
+- CHANGELOG `[Unreleased]`: Added — `Slide.RenderThumbnail` / `Pyramid.RenderThumbnail`.
+- Additive; no breaking changes; no behavior change to existing APIs.
+
+## 6. Out of scope
+
+- Falling back to / preferring an embedded associated image ("best-available").
+  Predictable always-render is simpler; a caller wanting the embedded macro for
+  navigation uses `AssociatedImages()` directly. Could be a future
+  `BestThumbnail`-style helper if a consumer asks.
+- Exact / stretched (non-aspect) output — use `ReadRegionScaled`.
+- Caching the rendered thumbnail — caller's concern.

--- a/docs/superpowers/specs/2026-06-18-render-thumbnail-design.md
+++ b/docs/superpowers/specs/2026-06-18-render-thumbnail-design.md
@@ -1,7 +1,12 @@
-# `RenderThumbnail` — rendered full-slide thumbnail/overview API — design
+# `RenderThumbnail` + `RenderMacro` — rendered slide-preview APIs — design
 
-**Status:** design / approved-to-implement
+**Status:** design / implemented
 **Date:** 2026-06-18
+
+> This spec covers two sibling additive APIs shipped together: `RenderThumbnail`
+> (tissue-extent downscale) and `RenderMacro` (tissue composited at true
+> physical scale onto a synthesized slide canvas). `RenderMacro` is specified in
+> §7.
 
 ---
 
@@ -106,3 +111,43 @@ propagate from `Level(0)`.
   `BestThumbnail`-style helper if a consumer asks.
 - Exact / stretched (non-aspect) output — use `ReadRegionScaled`.
 - Caching the rendered thumbnail — caller's concern.
+
+---
+
+## 7. `RenderMacro` — synthesized pseudo-macro (sibling feature)
+
+A viewer needs a macro-style orientation image even for slides that embed no
+macro. `RenderMacro` synthesizes one: a slide-shaped canvas (the **non-label
+scan area** of a standard slide, ~50×25 mm) with the whole-slide tissue
+composited at its **true physical size** and centred.
+
+```go
+func (s *Slide) RenderMacro(bounds Size, opts ...DecodeOption) (*decoder.Image, error)
+```
+
+- **Canvas = the non-label scan area** (`macroScanWidthMM=50`,
+  `macroScanHeightMM=25`), white. The label end is intentionally **excluded**
+  (a future option could include/draw it). `bounds` sizes the canvas with the
+  same zero-axis fit convention (scan area is ~2:1).
+- **Physical scale via `effectiveMPP`:** `Metadata.MPP` if present (a single
+  populated axis fills the other); else `10/Magnification` (objective rule of
+  thumb — 40×→0.25, 20×→0.5); else **error** (cannot place to scale).
+- **Tissue:** physical mm = `L0.Size × mpp / 1000`; rendered to exactly that px
+  size via `ReadRegionScaled` (stretch honours anisotropic MPP), blitted
+  **centred** on the white canvas. If the tissue exceeds the scan area it is
+  scaled to fit, preserving aspect. For BIF the tissue render is stitched.
+- **Position:** centred only — true on-slide placement (NDPI offset-from-centre,
+  SCN/DICOM/BIF slide-coordinate origin) is a deferred enhancement requiring a
+  new cross-format slide-coordinate metadata layer (not built here).
+
+**Helpers (pure, unit-tested):** `effectiveMPP(md) (x,y,err)` and
+`fitAspect(aw,ah, bounds) (Size,err)` (like `thumbnailTargetSize` but with no
+upscale clamp — the canvas is synthetic).
+
+**Tests:** unit (`fitAspect` fit-box/width/height/upscale/errors; `effectiveMPP`
+MPP / objective-fallback / neither-errors) + fixture-gated integration
+(canvas 600×300 for `bounds {600}`, composite = white background + centred
+tissue at physical scale).
+
+**Out of scope (now):** true position; drawing the label/frosted end;
+configurable slide/scan dimensions and colors (sensible fixed defaults for v1).

--- a/macro.go
+++ b/macro.go
@@ -1,0 +1,146 @@
+package opentile
+
+import (
+	"fmt"
+	"math"
+
+	"github.com/wsilabs/opentile-go/decoder"
+)
+
+// macroScanWidthMM / macroScanHeightMM are the physical dimensions of the
+// non-label scan area of a standard 1"×3" microscope slide (the coverslip
+// region), in millimetres. The label end (~25 mm) is intentionally excluded —
+// RenderMacro composites only this region. (Future option: include the label.)
+const (
+	macroScanWidthMM  = 50.0
+	macroScanHeightMM = 25.0
+)
+
+// RenderMacro renders a synthesized "pseudo-macro": a slide-shaped canvas
+// (the non-label scan area of a standard microscope slide, ~50×25 mm) with the
+// whole-slide tissue thumbnail composited at its TRUE physical size — derived
+// from the slide's microns-per-pixel — and centred. It gives a viewer a
+// macro-style orientation image for slides that don't embed one.
+//
+// `bounds` sizes the slide canvas (same zero-axis fit convention as
+// RenderThumbnail: a zero axis is unconstrained). The scan area is ~2:1, so
+// bounds {W:600} → a 600×300 canvas.
+//
+// Physical scale comes from Metadata.MPP; if that's absent, it falls back to
+// the objective magnification (mpp ≈ 10 / Magnification: 40× → 0.25, 20× → 0.5).
+// If the slide reports neither MPP nor magnification, RenderMacro returns an
+// error (it cannot place the tissue to scale).
+//
+// The tissue is centred (true on-slide POSITION is not yet modelled — a future
+// enhancement). If the tissue is physically larger than the scan area it is
+// scaled down to fit, preserving aspect. For BIF the tissue render is correctly
+// stitched. opts pass through to the tissue decode (e.g. WithFormat).
+func (s *Slide) RenderMacro(bounds Size, opts ...DecodeOption) (*decoder.Image, error) {
+	p := s.Pyramid(0)
+	if p == nil {
+		return nil, ErrImageIndexOutOfRange
+	}
+	l0, err := p.Level(0)
+	if err != nil {
+		return nil, err
+	}
+	mppX, mppY, err := effectiveMPP(s.Metadata())
+	if err != nil {
+		return nil, err
+	}
+
+	// Canvas = the scan area fitted into bounds.
+	canvas, err := fitAspect(macroScanWidthMM, macroScanHeightMM, bounds)
+	if err != nil {
+		return nil, err
+	}
+	pxPerMM := float64(canvas.W) / macroScanWidthMM
+
+	// Tissue physical extent (mm) → canvas pixels.
+	tissueWmm := float64(l0.Size.W) * mppX / 1000.0
+	tissueHmm := float64(l0.Size.H) * mppY / 1000.0
+	tw := int(tissueWmm*pxPerMM + 0.5)
+	th := int(tissueHmm*pxPerMM + 0.5)
+	// Clamp to the canvas if the tissue is physically larger than the scan area.
+	if tw > canvas.W || th > canvas.H {
+		fit := math.Min(float64(canvas.W)/float64(tw), float64(canvas.H)/float64(th))
+		tw = int(float64(tw)*fit + 0.5)
+		th = int(float64(th)*fit + 0.5)
+	}
+	if tw < 1 {
+		tw = 1
+	}
+	if th < 1 {
+		th = 1
+	}
+
+	// Render the tissue to exactly tw×th (ReadRegionScaled stretches L0 to the
+	// requested out size, so anisotropic MPP is honoured as physical proportion).
+	tissue, err := p.ReadRegionScaled(Region{Origin: Point{X: 0, Y: 0}, Size: l0.Size}, Size{W: tw, H: th}, opts...)
+	if err != nil {
+		return nil, err
+	}
+
+	cfg := newDecodeConfig(opts)
+	out := decoder.NewImageFormat(canvas.W, canvas.H, cfg.format)
+	fillWhite(out)
+	dstX := (canvas.W - tw) / 2
+	dstY := (canvas.H - th) / 2
+	blitInto(tissue, 0, 0, tw, th, out, dstX, dstY)
+	return out, nil
+}
+
+// effectiveMPP resolves the microns-per-pixel to use for physical scaling:
+// Metadata.MPP if present (a single populated axis fills the other), else
+// 10/Magnification (the standard objective rule of thumb: 40× → 0.25,
+// 20× → 0.5), else an error.
+func effectiveMPP(md Metadata) (x, y float64, err error) {
+	x, y = md.MPP.X, md.MPP.Y
+	if x == 0 {
+		x = y
+	}
+	if y == 0 {
+		y = x
+	}
+	if x > 0 && y > 0 {
+		return x, y, nil
+	}
+	if md.Magnification > 0 {
+		m := 10.0 / md.Magnification
+		return m, m, nil
+	}
+	return 0, 0, fmt.Errorf("opentile: RenderMacro: slide reports neither MPP nor objective magnification; cannot scale the macro accurately")
+}
+
+// fitAspect returns the largest Size with aspect aw:ah that fits within bounds,
+// where a zero (or negative) bounds axis is unconstrained. Unlike
+// thumbnailTargetSize it does NOT clamp to avoid upscaling — the macro canvas is
+// synthetic and may be rendered at any resolution. Errors if bounds constrains
+// neither axis or the aspect is degenerate.
+func fitAspect(aw, ah float64, bounds Size) (Size, error) {
+	if aw <= 0 || ah <= 0 {
+		return Size{}, fmt.Errorf("opentile: fitAspect: degenerate aspect %gx%g", aw, ah)
+	}
+	if bounds.W <= 0 && bounds.H <= 0 {
+		return Size{}, fmt.Errorf("opentile: RenderMacro: bounds must constrain at least one axis (got %dx%d)", bounds.W, bounds.H)
+	}
+	aspect := aw / ah
+	var w, h float64
+	switch {
+	case bounds.W > 0 && bounds.H > 0:
+		if float64(bounds.W)/float64(bounds.H) > aspect {
+			h = float64(bounds.H)
+			w = h * aspect
+		} else {
+			w = float64(bounds.W)
+			h = w / aspect
+		}
+	case bounds.W > 0:
+		w = float64(bounds.W)
+		h = w / aspect
+	default: // bounds.H > 0
+		h = float64(bounds.H)
+		w = h * aspect
+	}
+	return Size{W: max(1, int(w+0.5)), H: max(1, int(h+0.5))}, nil
+}

--- a/macro_integration_test.go
+++ b/macro_integration_test.go
@@ -1,0 +1,56 @@
+package opentile_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	opentile "github.com/wsilabs/opentile-go"
+	_ "github.com/wsilabs/opentile-go/decoder/all"
+	_ "github.com/wsilabs/opentile-go/formats/all"
+)
+
+// TestRenderMacroIntegration renders a synthesized macro from a real slide and
+// checks the canvas geometry + that it's a composite (white slide background +
+// tissue). Fixture-gated.
+func TestRenderMacroIntegration(t *testing.T) {
+	dir := os.Getenv("OPENTILE_TESTDIR")
+	if dir == "" {
+		t.Skip("OPENTILE_TESTDIR not set")
+	}
+	path := filepath.Join(dir, "svs", "CMU-1-Small-Region.svs")
+	if _, err := os.Stat(path); err != nil {
+		t.Skip("CMU-1-Small-Region.svs not present")
+	}
+	s, err := opentile.OpenFile(path)
+	if err != nil {
+		t.Fatalf("OpenFile: %v", err)
+	}
+	defer s.Close()
+
+	img, err := s.RenderMacro(opentile.Size{W: 600})
+	if err != nil {
+		t.Fatalf("RenderMacro: %v", err)
+	}
+	// Scan area is 50×25 mm (2:1) → fit-width 600 → 600×300.
+	if img.Width != 600 || img.Height != 300 {
+		t.Errorf("macro dims = %dx%d, want 600x300", img.Width, img.Height)
+	}
+	// Must be a composite: some white (slide background) AND some non-white
+	// (tissue). All-white = no tissue rendered; all-non-white = no margin.
+	white, nonWhite := 0, 0
+	for i := 0; i+2 < len(img.Pix); i += 3 {
+		if img.Pix[i] == 0xFF && img.Pix[i+1] == 0xFF && img.Pix[i+2] == 0xFF {
+			white++
+		} else {
+			nonWhite++
+		}
+	}
+	if white == 0 {
+		t.Error("no white background — tissue should not fill the whole canvas")
+	}
+	if nonWhite == 0 {
+		t.Error("entirely white — tissue not composited")
+	}
+	t.Logf("macro 600x300: white=%d nonWhite=%d", white, nonWhite)
+}

--- a/macro_test.go
+++ b/macro_test.go
@@ -1,0 +1,78 @@
+package opentile
+
+import (
+	"math"
+	"testing"
+)
+
+func TestFitAspect(t *testing.T) {
+	cases := []struct {
+		name   string
+		aw, ah float64
+		bounds Size
+		want   Size
+		err    bool
+	}{
+		// scan-area aspect 50:25 = 2:1
+		{"fit-box wide bounds → height binds", 50, 25, Size{600, 600}, Size{600, 300}, false},
+		{"fit-box tall bounds → width binds", 50, 25, Size{600, 100}, Size{200, 100}, false},
+		{"fit-width", 50, 25, Size{600, 0}, Size{600, 300}, false},
+		{"fit-height", 50, 25, Size{0, 100}, Size{200, 100}, false},
+		// NO upscale clamp (synthetic canvas can be any size, unlike thumbnail)
+		{"upscale allowed", 2, 1, Size{4000, 0}, Size{4000, 2000}, false},
+		{"both zero", 50, 25, Size{0, 0}, Size{}, true},
+		{"degenerate aspect", 0, 25, Size{600, 0}, Size{}, true},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got, err := fitAspect(c.aw, c.ah, c.bounds)
+			if c.err {
+				if err == nil {
+					t.Fatalf("want error, got %v", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != c.want {
+				t.Errorf("fitAspect(%g,%g,%v) = %v, want %v", c.aw, c.ah, c.bounds, got, c.want)
+			}
+		})
+	}
+}
+
+func TestEffectiveMPP(t *testing.T) {
+	cases := []struct {
+		name   string
+		md     Metadata
+		wx, wy float64
+		err    bool
+	}{
+		{"explicit MPP", Metadata{MPP: MPP{0.25, 0.25}}, 0.25, 0.25, false},
+		{"explicit asymmetric MPP", Metadata{MPP: MPP{0.25, 0.26}}, 0.25, 0.26, false},
+		{"MPP one-axis fills other", Metadata{MPP: MPP{0.5, 0}}, 0.5, 0.5, false},
+		{"objective 40x → 0.25", Metadata{Magnification: 40}, 0.25, 0.25, false},
+		{"objective 20x → 0.5", Metadata{Magnification: 20}, 0.5, 0.5, false},
+		{"objective 10x → 1.0", Metadata{Magnification: 10}, 1.0, 1.0, false},
+		{"MPP wins over objective", Metadata{MPP: MPP{0.23, 0.23}, Magnification: 40}, 0.23, 0.23, false},
+		{"neither → error", Metadata{}, 0, 0, true},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			x, y, err := effectiveMPP(c.md)
+			if c.err {
+				if err == nil {
+					t.Fatalf("want error, got %g,%g", x, y)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if math.Abs(x-c.wx) > 1e-9 || math.Abs(y-c.wy) > 1e-9 {
+				t.Errorf("effectiveMPP = %g,%g, want %g,%g", x, y, c.wx, c.wy)
+			}
+		})
+	}
+}

--- a/thumbnail.go
+++ b/thumbnail.go
@@ -1,0 +1,85 @@
+package opentile
+
+import (
+	"fmt"
+	"math"
+
+	"github.com/wsilabs/opentile-go/decoder"
+)
+
+// RenderThumbnail renders the whole slide (this pyramid) downscaled to fit
+// bounds, preserving aspect ratio, as a freshly-resampled image. A zero (or
+// negative) value on either axis of bounds is unconstrained — the output size
+// is derived from the other axis and the slide's aspect ratio:
+//
+//	bounds {W:256, H:256} → largest image fitting inside 256×256 (fit-box)
+//	bounds {W:256, H:0}   → width 256, height from aspect (fit-width)
+//	bounds {W:0,   H:256} → height 256, width from aspect (fit-height)
+//
+// It never upscales beyond level 0 (if bounds exceeds L0 the output is L0's
+// extent). The thumbnail is RENDERED from the image pyramid (best-level-sourced
+// and Lanczos-resampled via ReadRegionScaled, so memory stays bounded for large
+// slides) — it is NOT the embedded AssociatedThumbnail / AssociatedOverview;
+// use AssociatedImages() for those. For BIF the render is correctly stitched.
+//
+// Returns an error if bounds constrains neither axis, if level 0 is unavailable,
+// or (like ReadRegionScaled) if no decoder is registered for level 0's
+// compression. opts pass through to the underlying decode (e.g. WithFormat).
+func (p *Pyramid) RenderThumbnail(bounds Size, opts ...DecodeOption) (*decoder.Image, error) {
+	l0, err := p.Level(0)
+	if err != nil {
+		return nil, err
+	}
+	out, err := thumbnailTargetSize(l0.Size, bounds)
+	if err != nil {
+		return nil, err
+	}
+	src := Region{Origin: Point{X: 0, Y: 0}, Size: l0.Size}
+	return p.slide.imageReadRegionScaled(p.Index, src, out, opts...)
+}
+
+// RenderThumbnail renders the whole slide downscaled to fit bounds, using the
+// first pyramid. See (*Pyramid).RenderThumbnail for the sizing convention and
+// semantics. For multi-pyramid files (e.g. some OME-TIFF), use
+// s.Pyramid(i).RenderThumbnail to choose a specific pyramid.
+func (s *Slide) RenderThumbnail(bounds Size, opts ...DecodeOption) (*decoder.Image, error) {
+	p := s.Pyramid(0)
+	if p == nil {
+		return nil, ErrImageIndexOutOfRange
+	}
+	return p.RenderThumbnail(bounds, opts...)
+}
+
+// thumbnailTargetSize computes the aspect-preserving output size for fitting an
+// l0 (W×H) image into bounds. A zero or negative axis in bounds is
+// unconstrained (its scale is ignored). The scale is the most constraining of
+// the constrained axes, capped at 1.0 so a thumbnail never upscales past L0.
+// Each output axis floors at 1px. Errors if bounds constrains neither axis or
+// if l0 is degenerate.
+func thumbnailTargetSize(l0, bounds Size) (Size, error) {
+	if l0.W <= 0 || l0.H <= 0 {
+		return Size{}, fmt.Errorf("opentile: RenderThumbnail: level 0 has degenerate size %dx%d", l0.W, l0.H)
+	}
+	if bounds.W <= 0 && bounds.H <= 0 {
+		return Size{}, fmt.Errorf("opentile: RenderThumbnail: bounds must constrain at least one axis (got %dx%d)", bounds.W, bounds.H)
+	}
+	scale := math.Inf(1)
+	if bounds.W > 0 {
+		scale = math.Min(scale, float64(bounds.W)/float64(l0.W))
+	}
+	if bounds.H > 0 {
+		scale = math.Min(scale, float64(bounds.H)/float64(l0.H))
+	}
+	if scale > 1.0 {
+		scale = 1.0 // never upscale beyond L0
+	}
+	w := int(math.Round(float64(l0.W) * scale))
+	h := int(math.Round(float64(l0.H) * scale))
+	if w < 1 {
+		w = 1
+	}
+	if h < 1 {
+		h = 1
+	}
+	return Size{W: w, H: h}, nil
+}

--- a/thumbnail_integration_test.go
+++ b/thumbnail_integration_test.go
@@ -1,0 +1,94 @@
+package opentile_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	opentile "github.com/wsilabs/opentile-go"
+	"github.com/wsilabs/opentile-go/decoder"
+	_ "github.com/wsilabs/opentile-go/decoder/all"
+	_ "github.com/wsilabs/opentile-go/formats/all"
+)
+
+// TestRenderThumbnailIntegration renders thumbnails from a real slide and
+// checks the fit math + that real pixels come back. Fixture-gated.
+func TestRenderThumbnailIntegration(t *testing.T) {
+	dir := os.Getenv("OPENTILE_TESTDIR")
+	if dir == "" {
+		t.Skip("OPENTILE_TESTDIR not set")
+	}
+	path := filepath.Join(dir, "svs", "CMU-1-Small-Region.svs")
+	if _, err := os.Stat(path); err != nil {
+		t.Skip("CMU-1-Small-Region.svs not present")
+	}
+	s, err := opentile.OpenFile(path)
+	if err != nil {
+		t.Fatalf("OpenFile: %v", err)
+	}
+	defer s.Close()
+
+	l0 := s.Pyramid(0).Levels[0].Size
+	aspect := float64(l0.W) / float64(l0.H)
+
+	notAllWhite := func(t *testing.T, img *decoder.Image) {
+		t.Helper()
+		for i := 0; i+2 < len(img.Pix); i += 3 {
+			if img.Pix[i] != 0xFF || img.Pix[i+1] != 0xFF || img.Pix[i+2] != 0xFF {
+				return
+			}
+		}
+		t.Error("thumbnail is entirely white — render likely broken")
+	}
+
+	t.Run("fit-box 256", func(t *testing.T) {
+		img, err := s.RenderThumbnail(opentile.Size{W: 256, H: 256})
+		if err != nil {
+			t.Fatalf("RenderThumbnail: %v", err)
+		}
+		if img.Width > 256 || img.Height > 256 {
+			t.Errorf("dims %dx%d exceed 256×256 box", img.Width, img.Height)
+		}
+		if img.Width != 256 && img.Height != 256 {
+			t.Errorf("dims %dx%d: neither axis hit the 256 box bound", img.Width, img.Height)
+		}
+		// aspect preserved within ±1px
+		gotAspect := float64(img.Width) / float64(img.Height)
+		if d := gotAspect - aspect; d < -0.02 || d > 0.02 {
+			t.Errorf("aspect %.4f vs L0 %.4f (dims %dx%d)", gotAspect, aspect, img.Width, img.Height)
+		}
+		notAllWhite(t, img)
+	})
+
+	t.Run("fit-width 200", func(t *testing.T) {
+		img, err := s.RenderThumbnail(opentile.Size{W: 200, H: 0})
+		if err != nil {
+			t.Fatalf("RenderThumbnail: %v", err)
+		}
+		if img.Width != 200 {
+			t.Errorf("fit-width: got width %d, want 200", img.Width)
+		}
+		wantH := int(float64(200)/aspect + 0.5)
+		if d := img.Height - wantH; d < -1 || d > 1 {
+			t.Errorf("fit-width: height %d, want ≈%d (aspect)", img.Height, wantH)
+		}
+		notAllWhite(t, img)
+	})
+
+	t.Run("fit-height 200", func(t *testing.T) {
+		img, err := s.RenderThumbnail(opentile.Size{W: 0, H: 200})
+		if err != nil {
+			t.Fatalf("RenderThumbnail: %v", err)
+		}
+		if img.Height != 200 {
+			t.Errorf("fit-height: got height %d, want 200", img.Height)
+		}
+		notAllWhite(t, img)
+	})
+
+	t.Run("both-zero errors", func(t *testing.T) {
+		if _, err := s.RenderThumbnail(opentile.Size{W: 0, H: 0}); err == nil {
+			t.Error("want error for unconstrained bounds")
+		}
+	})
+}

--- a/thumbnail_test.go
+++ b/thumbnail_test.go
@@ -1,0 +1,51 @@
+package opentile
+
+import "testing"
+
+func TestThumbnailTargetSize(t *testing.T) {
+	cases := []struct {
+		name       string
+		l0, bounds Size
+		want       Size
+		wantErr    bool
+	}{
+		// fit-box: portrait L0, square box → height binds
+		{"fit-box portrait", Size{2000, 3000}, Size{256, 256}, Size{171, 256}, false},
+		// fit-box: landscape L0, square box → width binds
+		{"fit-box landscape", Size{3000, 2000}, Size{256, 256}, Size{256, 171}, false},
+		// fit-box: square L0
+		{"fit-box square", Size{1000, 1000}, Size{256, 256}, Size{256, 256}, false},
+		// fit-width: height derived from aspect
+		{"fit-width", Size{2000, 3000}, Size{256, 0}, Size{256, 384}, false},
+		// fit-height: width derived from aspect
+		{"fit-height", Size{2000, 3000}, Size{0, 256}, Size{171, 256}, false},
+		// no upscale: bounds bigger than L0 → clamp to L0
+		{"no-upscale box", Size{500, 800}, Size{4096, 4096}, Size{500, 800}, false},
+		{"no-upscale width", Size{500, 800}, Size{4096, 0}, Size{500, 800}, false},
+		// extreme downscale floors at 1px
+		{"1px floor", Size{100000, 50}, Size{0, 1}, Size{2000, 1}, false},
+		// both axes zero → error
+		{"both zero", Size{2000, 3000}, Size{0, 0}, Size{}, true},
+		// negative treated as unconstrained (W<0,H set → fit-height)
+		{"negative width unconstrained", Size{2000, 3000}, Size{-1, 256}, Size{171, 256}, false},
+		// degenerate L0 → error
+		{"empty l0", Size{0, 0}, Size{256, 256}, Size{}, true},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got, err := thumbnailTargetSize(c.l0, c.bounds)
+			if c.wantErr {
+				if err == nil {
+					t.Fatalf("want error, got %v", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != c.want {
+				t.Errorf("thumbnailTargetSize(%v, %v) = %v, want %v", c.l0, c.bounds, got, c.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Adds a discoverable convenience for generating a whole-slide thumbnail/overview from the pyramid — the thing opentile-go doesn't synthesize today (it only exposes *embedded* associated images). Needed by viewer consumers for (1) a slide-gallery preview and (2) a navigational overview/minimap.

## API

```go
func (s *Slide)   RenderThumbnail(bounds Size, opts ...DecodeOption) (*decoder.Image, error) // → Pyramid(0)
func (p *Pyramid) RenderThumbnail(bounds Size, opts ...DecodeOption) (*decoder.Image, error)
```

**Sizing** — `bounds Size` where a zero axis is *unconstrained* (derive from aspect), the ImageMagick `256x` / `x256` / `256x256` convention:

| `bounds` | result |
|---|---|
| `{W:256, H:256}` | largest aspect-preserved image fitting inside 256×256 (**fit-box**) |
| `{W:256, H:0}` | **fit-width** — width 256, height from aspect |
| `{W:0, H:256}` | **fit-height** — height 256, width from aspect |
| `{W:0, H:0}` | error |

One `Size` covers every "sometimes width, sometimes height" case — no mode enum.

## Behavior

- **Always renders from the pyramid** (predictable, uniform tissue-extent thumbnails for a gallery); it is **not** the embedded `AssociatedThumbnail`/`AssociatedOverview` — those stay on `AssociatedImages()`. Documented.
- Aspect-preserving; **never upscales past L0**.
- Thin wrapper over `ReadRegionScaled` → best-level-sourced + Lanczos, memory bounded. For **BIF the render is correctly stitched** (free from v0.46.0).
- `opts` pass through (`WithFormat`, …).

## Why not just use ReadRegionScaled?

You can — `RenderThumbnail` *is* `ReadRegionScaled(fullL0, fitBox(bounds))`. The value is owning the aspect-fit math (easy to get wrong on non-square slides), discoverability (openslide `get_thumbnail` parity), and a clean rendered-vs-embedded distinction.

## Tests

- Fixture-free unit tests for the fit math: fit-box (portrait/landscape/square), fit-width, fit-height, no-upscale clamp, 1px floor, both-zero/degenerate errors.
- Fixture-gated integration test on `CMU-1-Small-Region.svs`: fit-box/width/height dims + aspect + non-white pixels.
- `make test` green under `-race`; additive, no behavior change to existing APIs.

Spec: `docs/superpowers/specs/2026-06-18-render-thumbnail-design.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)