### PR TITLE
fix: ScaledStrips spurious "tile missing from cache" eviction race

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,21 @@ The single source of truth for "what was deferred and why" is
 front-page summary; the deferred file has the full reasoning,
 upstream references, and retirement audit per milestone.
 
+## [Unreleased]
+
+### Fixed
+
+- **`ScaledStrips` / `ReadRegionScaled`: spurious "tile missing from cache"
+  race.** The strip iterator's per-tile read did `reserve()` then `waitGet()` in
+  two separate cache-lock holds; between them a concurrent reservation (lookahead
+  prefetch) or `put()` (decode worker) could `evictLocked` the just-produced,
+  unpinned entry, so `waitGet()` reported the tile missing and the read failed.
+  The consumer now reserves-and-pins atomically (`reserveOrAcquire`) and holds
+  the pin through `waitGet` + blit, so the entry can't be evicted out from under
+  it. Pre-existing intermittent CI flake; no API change. The cache's
+  `acquire`/`release` refcount pin (previously unused by the read path) now
+  guards the read.
+
 ## [0.47.0] — 2026-06-18
 
 Rendered slide-preview APIs — `RenderThumbnail` and `RenderMacro`.

--- a/strip_cache.go
+++ b/strip_cache.go
@@ -67,6 +67,31 @@ func (c *tileCache) reserve(k tileKey) bool {
 	return true
 }
 
+// reserveOrAcquire ensures k has an entry and pins it for the caller
+// (refCount++), atomically under the lock — so no concurrent eviction can drop
+// k between reserving it and the caller's subsequent waitGet/use. Returns
+// created=true when the entry was newly reserved (the caller must then send a
+// decode request); false when k already existed (in-flight or produced). The
+// caller MUST release(k) when done with the tile.
+//
+// This closes the window the plain reserve()+waitGet() sequence left open: an
+// unpinned, produced entry could be evicted between the two lock holds, making
+// waitGet() report the tile "missing from cache".
+func (c *tileCache) reserveOrAcquire(k tileKey) (created bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if e, exists := c.entries[k]; exists {
+		e.refCount++
+		c.lru.MoveToFront(e.lruElem)
+		return false
+	}
+	c.evictLocked()
+	e := &tileEntry{ready: make(chan struct{}), refCount: 1}
+	e.lruElem = c.lru.PushFront(k)
+	c.entries[k] = e
+	return true
+}
+
 // put stores a decoded tile (or error) at k. If k was reserved,
 // closes the ready channel so waiting waitGet() callers unblock.
 // If k was not reserved, the entry is born ready (no ready channel).

--- a/strip_cache_test.go
+++ b/strip_cache_test.go
@@ -157,3 +157,43 @@ func TestTileCacheConcurrentAccess(t *testing.T) {
 	}
 	wg.Wait()
 }
+
+// TestTileCacheReserveOrAcquirePinsAgainstEviction is the regression for the
+// "tile missing from cache" flake: the consumer's reserve()+waitGet() left a
+// window in which an unpinned, produced entry could be evicted between the two
+// lock holds. reserveOrAcquire pins atomically, so a held tile survives churn.
+func TestTileCacheReserveOrAcquirePinsAgainstEviction(t *testing.T) {
+	c := newTileCache(2) // tiny → every new reservation forces an eviction
+	k0 := tileKey{0, 0}
+	if created := c.reserveOrAcquire(k0); !created {
+		t.Fatal("k0 should be newly created")
+	}
+	c.put(k0, decoder.NewImage(1, 1), nil)
+
+	// Churn many other tiles through the 2-slot cache. Each is pinned for its
+	// turn then released, so it becomes the eviction victim — never k0, which
+	// stays pinned.
+	for i := 1; i <= 32; i++ {
+		ki := tileKey{i, 0}
+		c.reserveOrAcquire(ki)
+		c.put(ki, decoder.NewImage(1, 1), nil)
+		c.release(ki)
+	}
+
+	// k0 was pinned the whole time → must still be retrievable.
+	img, err, ok := c.waitGet(k0, nil)
+	if !ok || img == nil || err != nil {
+		t.Fatalf("pinned k0 was evicted: ok=%v img=%v err=%v", ok, img, err)
+	}
+	c.release(k0)
+
+	// reserveOrAcquire reports created correctly: existing → false, fresh → true.
+	if created := c.reserveOrAcquire(k0); created {
+		t.Error("k0 still present, want created=false")
+	}
+	c.release(k0)
+	if created := c.reserveOrAcquire(tileKey{999, 999}); !created {
+		t.Error("fresh key, want created=true")
+	}
+	c.release(tileKey{999, 999})
+}

--- a/strip_iterator.go
+++ b/strip_iterator.go
@@ -251,10 +251,13 @@ func (it *StripIterator) Next() (*decoder.Image, error) {
 	// blitOneTile is the shared blit helper used by both the naive and
 	// layout-aware tile loop below.
 	blitOneTile := func(k tileKey, tileLevelX, tileLevelY int) error {
-		// Reserve in case lookahead hasn't gotten to it yet, then hand
-		// the request to a worker. tileReqs is never closed (workers
-		// exit via cancelCtx), so this send never races a close.
-		if it.cache.reserve(k) {
+		// Reserve-AND-pin atomically (reserveOrAcquire) so the entry can't be
+		// evicted between here and waitGet/blit; release once we're done with
+		// it. If newly reserved, hand the request to a worker. tileReqs is never
+		// closed (workers exit via cancelCtx), so this send never races a close.
+		created := it.cache.reserveOrAcquire(k)
+		defer it.cache.release(k)
+		if created {
 			select {
 			case it.tileReqs <- k:
 			case <-it.cancelCtx.Done():


### PR DESCRIPTION
Fixes the intermittent CI flake (`region_scaled_test.go: ScaledStrips: tile (0,0) missing from cache`) that surfaced again on the v0.47.0 main run.

## Root cause

The strip iterator's per-tile read (`blitOneTile` in `strip_iterator.go`) did this across **two separate cache-lock holds**:

```go
if it.cache.reserve(k) { … send decode request … }   // lock hold #1
tileImg, _, _ := it.cache.waitGet(k, ctx)             // lock hold #2
```

Between the two, a concurrent `reserve()` (the lookahead prefetch goroutine) or `put()` (a decode worker) can run `evictLocked`, which evicts the LRU entry that is **unpinned (`refCount==0`) and produced (`ready==nil`)** — i.e. the very tile this consumer just got produced and is about to read. `waitGet` then finds the entry gone and returns `(nil, nil)`, so the read fails with "tile missing from cache".

The cache already had an `acquire`/`release` **refcount pin** for exactly this — but the read path never used it (it was effectively dead code).

## Fix

Add `tileCache.reserveOrAcquire(k)` — reserve-and-pin **atomically** in one lock hold (refCount++ on an existing entry, or create a fresh reserved+pinned entry). `blitOneTile` now pins via `reserveOrAcquire` and holds the pin (`defer release`) through `waitGet` + blit, so `evictLocked` (which skips pinned entries) can't drop it mid-read. The lookahead keeps plain `reserve()` (warming, unpinned). No API change.

## Verification

- **Deterministic cache regression test** (`TestTileCacheReserveOrAcquirePinsAgainstEviction`): a pinned tile survives 32-tile churn through a 2-slot cache; verifies the `created` return.
- **Stress**: `ReadRegionScaled` / `ScaledStrips` / `Strip` / `TileCache` under `-race -count=15` — green (was an intermittent failure). Full suite green under `-race`.

This race is reachable from `ReadRegionScaled` (codec-scale fast path → strip iterator) and therefore from `RenderThumbnail` / `RenderMacro` too, so it's worth nailing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)