### PR TITLE
feat: Level.Overlapping — stitched-tile contract signal (#71)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,21 @@ The single source of truth for "what was deferred and why" is
 front-page summary; the deferred file has the full reasoning,
 upstream references, and retirement audit per milestone.
 
+## [Unreleased]
+
+### Added
+
+- **`Level.Overlapping bool`** (#71) — explicit signal that a level's stored
+  tiles overlap, so `Grid` does **not** tile `Size` (`Grid.W × TileSize.W >
+  Size.W`). True only for stitched BIF levels (#60); false for every other
+  format and for non-overlapping BIF levels. Consumers that re-tile / reassemble
+  pixels must route through the region API (`ReadRegion` / `ReadRegionScaled` /
+  `ScaledStrips`) when `Overlapping` is true, and gate any verbatim per-tile-copy
+  fast path on `!Overlapping` — the per-tile accessors (`Tile` / `DecodedTile` /
+  `Grid` iteration) return the raw overlapping tiles, not a partition of the
+  stitched image. Documented the contract on `Level.Grid` / `Level.Overlapping`
+  and in `docs/formats/bif.md`. Additive; no behavior change.
+
 ## [0.47.1] — 2026-06-18
 
 ### Fixed

--- a/docs/formats/bif.md
+++ b/docs/formats/bif.md
@@ -12,7 +12,7 @@ Roche's WSI format for the VENTANA DP family of scanners (DP 200, DP 600, …) a
 - **Pyramid layout**: top-level IFDs sorted by parsed `level=N` from each IFD's ImageDescription. Spec describes IFD 0 = label, IFD 1 = probability, IFD 2 = scan, IFD 3+ = pyramid; **OS-1 (legacy) violates this**: IFD 0 = label, IFD 1 = thumbnail, IFD 2..11 = pyramid (no probability). v0.7 classifies by ImageDescription content, not by IFD index.
 - **Compression**: JPEG (tag 7) on every pyramid IFD. Associated images: NONE (Ventana-1 IFD 0 RGB raw strips), LZW (Ventana-1 IFD 1 grayscale probability strips), or JPEG (OS-1 IFD 0/1 single-tile).
 - **Storage order**: `TILE_OFFSETS` is **row-major**, top-left origin — the order declared by the `<Frame>` nodes (`Frame[k] = (k % cols, k / cols)`), and the order legacy iScan files (which carry no `<Frame>` nodes) use too. `formats/bif/level.go` honors the `<Frame>` nodes when they form a complete per-tile permutation of the grid (`buildFrameIndex`), otherwise maps row-major. Verified against **bio-formats** (`TestBIFTilePlacementSpatial` — the tissue lands in the correct half of a multi-tile level; openslide rejects this DP 200 file). BIF *also* uses **serpentine** numbering, but only for the `TileJointInfo` `Tile1`/`Tile2` stitch-graph IDs (whitepaper Fig 2) — NOT for pixel storage. Earlier opentile-go conflated the two and applied serpentine to `TILE_OFFSETS`, which scrambled multi-tile levels (#57). Per-index raw-byte fidelity is checked against tifffile (`TestTifffileParityBIF`), which is placement-agnostic — it confirms the bytes, not the placement (that's what the bio-formats spatial oracle is for; #59).
-- **Tile overlap**: spec-compliant DP 200 slides record per-tile-pair overlap in the `<EncodeInfo>/<SlideStitchInfo>/<ImageInfo>/<TileJointInfo>` XMP elements. v0.7 collapses these to a single weighted-average `image.Point` per level, exposed via the new `Level.TileOverlap()` interface method. Pyramid IFDs 1+ are non-overlapping per spec.
+- **Tile overlap**: spec-compliant DP 200 slides record per-tile-pair overlap in the `<EncodeInfo>/<SlideStitchInfo>/<ImageInfo>/<TileJointInfo>` XMP elements. v0.7 collapses these to a single weighted-average `Point` per level, exposed via the `Level.TileOverlap` field (magnitude); the boolean "this level's tiles overlap, so `Grid` does not tile `Size`" contract signal is `Level.Overlapping` (#71). Pyramid IFDs 1+ are non-overlapping per spec.
 
 ## Fixture inventory
 
@@ -52,6 +52,17 @@ BIF tiles are **overlapping camera frames**: adjacent frames share a small borde
 ### Level.Size, ReadRegion, and scaled APIs
 
 `Level.Size` (and by extension `ReadRegion`, `ReadRegionScaled`, and `ScaledStrips` / DZI output) report and produce the **stitched content extent** — the pixel hull after overlap compaction. This is the meaningful slide area a consumer would display; it is smaller than (or equal to) the raw frame-grid extent `Grid.W×TileSize.W × Grid.H×TileSize.H`.
+
+### The two-grid contract — `Level.Overlapping` (GH #71)
+
+A stitched level has **two grids** that disagree, and `Level.Overlapping` is the signal:
+
+- `Level.Size` is the **stitched** content hull (e.g. Ventana-1 L0 = 23432×21504).
+- `Level.Grid` is the **raw stored tile grid** of *overlapping* tiles (e.g. 24×21), which does **not** tile `Size` — `Grid.W × TileSize.W > Size.W`.
+
+For a stitched level `Level.Overlapping == true`. The **per-tile** accessors (`Tile`, `TileInto`, `DecodedTile`, `Tiles`, indexed by `Grid`) return the **raw overlapping tiles at their stored positions** — they are *not* a clean partition of the stitched image. The **region** accessors (`ReadRegion`, `ReadRegionScaled`, `ScaledStrips`) composite the stitched image and are the correct path for re-tiling / pixel reassembly.
+
+**Consumer contract:** if `Level.Overlapping`, do **not** iterate `Grid` as if it tiled `Size`; route pixel reassembly through the region API (gate any verbatim per-tile-copy fast path on `!Overlapping`). `Overlapping` is `false` for every non-BIF format and for non-overlapping BIF levels (pyramid levels ≥1 are pre-stitched). `Level.TileOverlap` carries the overlap magnitude.
 
 ### DP generation (VENTANA DP 200 / DP 600) — pixel-exact stitching
 

--- a/formats/bif/bif.go
+++ b/formats/bif/bif.go
@@ -101,6 +101,7 @@ func openFromTIFFFile(file *tiff.File, cfg *format.Config) (format.Reader, error
 			Compression:  l.compression,
 			MPP:          l.mpp,
 			TileOverlap:  l.tileOverlap,
+			Overlapping:  l.overlapping,
 			FocalPlane:   0,
 			// l0Width is the level-0 STITCHED width (the compacted hull, #60);
 			// lower levels report their own IFD extent (pre-stitched, no joints

--- a/formats/bif/level.go
+++ b/formats/bif/level.go
@@ -41,6 +41,7 @@ type levelImpl struct {
 	compression opentile.Compression
 	mpp         opentile.MPP
 	tileOverlap opentile.Point // non-zero only on level 0 of overlapping spec-compliant slides
+	overlapping bool           // true when the stitch layout compacted the grid (raw tiles overlap; Grid does NOT tile Size — see opentile.Level.Overlapping, GH #71)
 
 	offsets []uint64 // TileOffsets, in row-major (TILE_OFFSETS / <Frame>) storage order
 	counts  []uint64 // TileByteCounts, in row-major storage order
@@ -226,6 +227,12 @@ func newLevelImpl(
 		size = opentile.Size{W: layout.Width, H: layout.Height}
 	}
 
+	// overlapping: the layout compacted the grid, so the stored tiles overlap
+	// and Grid does NOT tile Size — consumers must use the region API, not
+	// per-tile Grid iteration (GH #71). buildNaiveLayout sets Width = cols*tileW
+	// exactly, so this is false for non-compacted (lower / zero-overlap) levels.
+	overlapping := layout.Width < cols*int(tw) || layout.Height < rows*int(tl)
+
 	return &levelImpl{
 		index:          index,
 		pyrIndex:       c.Level,
@@ -235,6 +242,7 @@ func newLevelImpl(
 		compression:    ocomp,
 		mpp:            mpp,
 		tileOverlap:    tileOverlap,
+		overlapping:    overlapping,
 		frameIndex:     buildFrameIndex(encodeInfo, cols, rows, imageDepth),
 		offsets:        offsets,
 		counts:         counts,

--- a/image.go
+++ b/image.go
@@ -24,12 +24,32 @@ type Level struct {
 	// TileSize is the tile dimensions used by this level.
 	TileSize Size
 
-	// Grid is the tile grid dimensions: ceil(Size / TileSize) per axis.
-	// Pre-computed for convenience.
+	// Grid is the tile grid dimensions: ceil(Size / TileSize) per axis
+	// for ordinary (non-overlapping) levels. Pre-computed for convenience.
+	//
+	// IMPORTANT: when Overlapping is true (a stitched BIF level), Grid is the
+	// RAW stored tile grid of OVERLAPPING tiles and does NOT tile Size —
+	// Grid.W × TileSize.W > Size.W. Per-tile reads (Tile / TileInto /
+	// DecodedTile / Tiles) address those raw overlapping tiles at their stored
+	// positions, NOT a clean partition of the stitched image. Consumers that
+	// re-tile or reassemble pixels must use the region API (ReadRegion /
+	// ReadRegionScaled / ScaledStrips), which composites the stitched image;
+	// do not iterate Grid as if it tiled Size. See Overlapping.
 	Grid Size
 
+	// Overlapping reports whether this level's stored tiles overlap, so that
+	// Grid does NOT tile Size (Grid.W × TileSize.W > Size.W). True only for
+	// stitched BIF levels (GH #60/#71); false for every other format and for
+	// non-overlapping BIF levels. When true, use the region API (ReadRegion /
+	// ReadRegionScaled / ScaledStrips) rather than per-tile Grid iteration to
+	// obtain correctly-placed pixels; the per-tile accessors still return the
+	// raw overlapping tiles for callers that want them. TileOverlap carries the
+	// overlap magnitude.
+	Overlapping bool
+
 	// TileOverlap is the per-tile overlap (BIF / NDPI in overlapping
-	// modes). Zero for non-overlapping tile formats.
+	// modes). Zero for non-overlapping tile formats. See Overlapping for the
+	// boolean "Grid does not tile Size" contract signal.
 	TileOverlap Point
 
 	// Compression identifies the codec for tile bytes at this level.

--- a/overlapping_test.go
+++ b/overlapping_test.go
@@ -1,0 +1,70 @@
+package opentile_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	opentile "github.com/wsilabs/opentile-go"
+	_ "github.com/wsilabs/opentile-go/formats/all"
+)
+
+// TestLevelOverlappingContract verifies the GH #71 signal: stitched BIF levels
+// report Overlapping=true (Grid does NOT tile Size), and ordinary formats
+// report false (Grid tiles Size). Fixture-gated.
+func TestLevelOverlappingContract(t *testing.T) {
+	dir := os.Getenv("OPENTILE_TESTDIR")
+	if dir == "" {
+		t.Skip("OPENTILE_TESTDIR not set")
+	}
+
+	t.Run("stitched BIF L0 overlapping", func(t *testing.T) {
+		path := filepath.Join(dir, "bif", "Ventana-1.bif")
+		if _, err := os.Stat(path); err != nil {
+			t.Skip("Ventana-1.bif not present")
+		}
+		s, err := opentile.OpenFile(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer s.Close()
+		levels := s.Levels()
+		l0 := levels[0]
+		if !l0.Overlapping {
+			t.Errorf("stitched BIF L0: Overlapping=false, want true")
+		}
+		// The defining property: the raw grid does NOT tile the stitched Size.
+		if l0.Grid.W*l0.TileSize.W <= l0.Size.W {
+			t.Errorf("L0 Grid.W×TileSize.W (%d) should exceed Size.W (%d) for an overlapping level",
+				l0.Grid.W*l0.TileSize.W, l0.Size.W)
+		}
+		// A lower (pre-stitched) level must NOT be overlapping.
+		if len(levels) > 1 {
+			last := levels[len(levels)-1]
+			if last.Overlapping {
+				t.Errorf("BIF lower level %d: Overlapping=true, want false (pre-stitched)", last.Index)
+			}
+		}
+	})
+
+	t.Run("ordinary format not overlapping", func(t *testing.T) {
+		path := filepath.Join(dir, "svs", "CMU-1-Small-Region.svs")
+		if _, err := os.Stat(path); err != nil {
+			t.Skip("CMU-1-Small-Region.svs not present")
+		}
+		s, err := opentile.OpenFile(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer s.Close()
+		for _, l := range s.Levels() {
+			if l.Overlapping {
+				t.Errorf("SVS level %d: Overlapping=true, want false", l.Index)
+			}
+			// Grid must tile Size (ceil) for a non-overlapping level.
+			if l.Grid.W*l.TileSize.W < l.Size.W || l.Grid.H*l.TileSize.H < l.Size.H {
+				t.Errorf("SVS level %d: Grid does not cover Size", l.Index)
+			}
+		}
+	})
+}


### PR DESCRIPTION
Closes #71. The #60 BIF stitching made stitched levels report `Size` as the compacted hull while `Grid` stays the **raw overlapping** tile grid — so `Grid` no longer tiles `Size`, with **no signal**. Per-tile (re-tiling) consumers that pair `Grid` with `Size` (wsitools' convert paths) broke: out-of-grid errors / panic / silent misplacement; only `ScaledStrips`/`ReadRegion` consumers stayed correct.

## Fix — Option A (the issue's recommendation, minimal)

`Level.Overlapping bool` — explicit "this level's stored tiles overlap, so `Grid` does **not** tile `Size`" flag.

```go
if lvl.Overlapping {
    // Grid is raw overlapping tiles; use ReadRegion / ReadRegionScaled / ScaledStrips.
} else {
    // Grid tiles Size; per-tile copy is safe.
}
```

- **Set authoritatively, not derived:** BIF sets it `true` exactly when the stitch layout compacted the grid (`layout.Width < cols*tileW || layout.Height < rows*tileH`). This is robust against the rounding edge of the existing `TileOverlap` magnitude, and does **not** false-positive on ordinary partial-edge tiles (naive layouts set `Width = cols*tileW` exactly).
- **A field, not a method** — consistent with `Size`/`Grid`/`TileSize`/`TileOverlap` on the value struct; works on metadata-only `Level`s.
- `false` for every non-BIF format and for non-overlapping BIF levels (pyramid levels ≥1 are pre-stitched).

## Contract documented

On `Level.Grid`, `Level.Overlapping`, and in `docs/formats/bif.md`: when `Overlapping`, the per-tile accessors (`Tile`/`TileInto`/`DecodedTile`/`Tiles`, indexed by `Grid`) return raw overlapping tiles at their stored positions — *not* a partition of the stitched image — and pixel reassembly must go through the region API. `TileOverlap` carries the overlap magnitude; `Overlapping` is the boolean contract flag.

This lets wsitools replace its `Grid.X > ceil(Size.X/TileSize.X)` heuristic and gate its verbatim tile-copy fast path on `!Overlapping`.

## Tests

Fixture-gated contract test: Ventana-1 L0 `Overlapping=true` **and** `Grid.W×TileSize.W > Size.W`; a lower (pre-stitched) level + a non-overlapping SVS report `false` (and `Grid` covers `Size`). `make test` green under `-race`. Additive — no behavior change to existing APIs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)