### PR TITLE
feat(opentile): Level.StitchedTileInto — allocation-free display tile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ The single source of truth for "what was deferred and why" is
 front-page summary; the deferred file has the full reasoning,
 upstream references, and retirement audit per milestone.
 
+## [0.51.0] — 2026-06-24
+
+### Added
+
+- **`(*Level).StitchedTileInto`** — the allocation-free form of `StitchedTile`:
+  composites the display tile into a caller-provided `dst` (must be `TileSize`),
+  in `dst`'s own pixel format, white-filling first. Reuse one `dst` across a
+  display-grid traversal to avoid a per-tile allocation (mirrors
+  `DecodedTileInto` / `ReadRegionInto`). Delegates to `DecodedTileInto` for
+  non-overlapping levels. `StitchedTile` now allocates and delegates to it, so
+  the two share one composite path. Additive.
+
 ## [0.50.0] — 2026-06-24
 
 `StitchedTile` — clean display tiles for overlapping-tile formats.

--- a/level_reads.go
+++ b/level_reads.go
@@ -110,6 +110,16 @@ func (l *Level) StitchedTile(tx, ty int, opts ...DecodeOption) (*decoder.Image, 
 	return l.slide.imageStitchedTile(l.PyramidIndex, l.Index, tx, ty, opts...)
 }
 
+// StitchedTileInto is the allocation-free form of StitchedTile: it composites
+// the display tile (tx, ty) into the caller-provided dst, which must be exactly
+// the level's TileSize. The composite is done in dst's own pixel format, and
+// dst is white-filled before compositing. Reuse one dst across a display-grid
+// traversal to avoid a per-tile allocation. Returns an error if dst is nil or
+// not TileSize. Behaves exactly like DecodedTileInto for non-overlapping levels.
+func (l *Level) StitchedTileInto(tx, ty int, dst *decoder.Image, opts ...DecodeOption) error {
+	return l.slide.imageStitchedTileInto(l.PyramidIndex, l.Index, tx, ty, dst, opts...)
+}
+
 // StitchedGrid is the canonical display grid, ceil(Size/TileSize) per axis — a
 // clean partition of Size. Equals Grid for non-overlapping levels; for an
 // overlapping level it is the grid that tiles Size (whereas Grid stays the raw

--- a/stitched_tile.go
+++ b/stitched_tile.go
@@ -1,6 +1,10 @@
 package opentile
 
-import "github.com/wsilabs/opentile-go/decoder"
+import (
+	"fmt"
+
+	"github.com/wsilabs/opentile-go/decoder"
+)
 
 // compositeStitchedLoop blits every regionLayout tile intersecting the clipped
 // rectangle [x0,y0,x1,y1) into dst, which represents the stitched-space
@@ -62,19 +66,46 @@ func (s *Slide) frameCacheFor() *decodedFrameCache {
 // Scale > 1 is unsupported on overlapping levels (use ScaledStrips /
 // ReadRegionScaled for scaled traversal); it returns decoder.ErrUnsupportedScale.
 func (s *Slide) imageStitchedTile(image, level, tx, ty int, opts ...DecodeOption) (*decoder.Image, error) {
-	rl, ok := regionLayoutOf(s.r)
-	if !ok {
+	if _, ok := regionLayoutOf(s.r); !ok {
 		return s.imageDecodedTile(image, level, tx, ty, opts...)
 	}
 	lvl, err := s.r.Level(image, level)
 	if err != nil {
 		return nil, err
 	}
-	cfg := newDecodeConfig(opts)
-	if cfg.scale > 1 {
-		return nil, decoder.ErrUnsupportedScale
+	dst := decoder.NewImageFormat(lvl.TileSize.W, lvl.TileSize.H, newDecodeConfig(opts).format)
+	if err := s.imageStitchedTileInto(image, level, tx, ty, dst, opts...); err != nil {
+		return nil, err
+	}
+	return dst, nil
+}
+
+// imageStitchedTileInto is the allocation-free form of imageStitchedTile: it
+// composites the display tile (tx,ty) into the caller-provided dst, which must
+// be exactly the level's TileSize. dst is white-filled before compositing
+// (overlaps/gaps and out-of-hull remainders stay white). The cache, scale, and
+// no-layout-delegation semantics are identical to imageStitchedTile; the
+// composite is done in dst's own pixel format.
+func (s *Slide) imageStitchedTileInto(image, level, tx, ty int, dst *decoder.Image, opts ...DecodeOption) error {
+	if dst == nil {
+		return fmt.Errorf("opentile: StitchedTileInto: dst is nil")
+	}
+	rl, ok := regionLayoutOf(s.r)
+	if !ok {
+		return s.imageDecodedTileInto(image, level, tx, ty, dst, opts...)
+	}
+	lvl, err := s.r.Level(image, level)
+	if err != nil {
+		return err
+	}
+	if newDecodeConfig(opts).scale > 1 {
+		return decoder.ErrUnsupportedScale
 	}
 	tileW, tileH := lvl.TileSize.W, lvl.TileSize.H
+	if dst.Width != tileW || dst.Height != tileH {
+		return fmt.Errorf("opentile: StitchedTileInto: dst is %dx%d, want TileSize %dx%d",
+			dst.Width, dst.Height, tileW, tileH)
+	}
 	x0, y0 := tx*tileW, ty*tileH
 	x1, y1 := x0+tileW, y0+tileH
 	if sw, sh, ok := rl.StitchedSize(level); ok {
@@ -85,21 +116,21 @@ func (s *Slide) imageStitchedTile(image, level, tx, ty int, opts ...DecodeOption
 			y1 = sh
 		}
 	}
-	dst := decoder.NewImageFormat(tileW, tileH, cfg.format)
 	fillWhite(dst)
 	if x0 >= x1 || y0 >= y1 {
-		return dst, nil // fully outside the stitched hull → white tile
+		return nil // fully outside the stitched hull → white tile
 	}
 	fc := s.frameCacheFor()
-	err = compositeStitchedLoop(rl, level, x0, y0, x0, y0, x1, y1, tileW, tileH, dst,
+	// Composite in dst's format: blitInto requires src and dst share a format,
+	// and the cache frames must be decoded accordingly. Use a copy of opts with
+	// the format pinned to dst.Format (full-slice cap so the caller's backing
+	// array is never mutated).
+	loadOpts := append(opts[:len(opts):len(opts)], WithFormat(dst.Format))
+	return compositeStitchedLoop(rl, level, x0, y0, x0, y0, x1, y1, tileW, tileH, dst,
 		func(col, row int) (*decoder.Image, error) {
-			key := frameCacheKey{image: image, level: level, col: col, row: row, format: cfg.format}
+			key := frameCacheKey{image: image, level: level, col: col, row: row, format: dst.Format}
 			return fc.getOrLoad(key, func() (*decoder.Image, error) {
-				return s.imageDecodedTile(image, level, col, row, opts...)
+				return s.imageDecodedTile(image, level, col, row, loadOpts...)
 			})
 		})
-	if err != nil {
-		return nil, err
-	}
-	return dst, nil
 }

--- a/stitched_tile_into_test.go
+++ b/stitched_tile_into_test.go
@@ -1,0 +1,88 @@
+package opentile
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/wsilabs/opentile-go/decoder"
+)
+
+// imageStitchedTileInto must produce byte-identical pixels to the allocating
+// imageStitchedTile for every canonical display tile.
+func TestStitchedTileIntoEqualsStitchedTile(t *testing.T) {
+	f := newFakeStitchReader()
+	s := &Slide{r: f, readBudget: 64 << 20}
+	lvl, _ := f.Level(0, 0)
+	gw := ceilDiv(lvl.Size.W, lvl.TileSize.W)
+	gh := ceilDiv(lvl.Size.H, lvl.TileSize.H)
+
+	for vy := 0; vy < gh; vy++ {
+		for vx := 0; vx < gw; vx++ {
+			want, err := s.imageStitchedTile(0, 0, vx, vy)
+			if err != nil {
+				t.Fatalf("StitchedTile(%d,%d): %v", vx, vy, err)
+			}
+			dst := decoder.NewImageFormat(lvl.TileSize.W, lvl.TileSize.H, decoder.PixelFormatRGB)
+			if err := s.imageStitchedTileInto(0, 0, vx, vy, dst); err != nil {
+				t.Fatalf("StitchedTileInto(%d,%d): %v", vx, vy, err)
+			}
+			if !bytes.Equal(dst.Pix, want.Pix) {
+				t.Fatalf("tile (%d,%d): Into pixels differ from StitchedTile", vx, vy)
+			}
+		}
+	}
+}
+
+// Reusing one dst across tiles must yield correct, independent results — the
+// white-fill + composite must fully overwrite the previous tile.
+func TestStitchedTileIntoReuseBuffer(t *testing.T) {
+	f := newFakeStitchReader()
+	s := &Slide{r: f, readBudget: 64 << 20}
+	lvl, _ := f.Level(0, 0)
+	dst := decoder.NewImageFormat(lvl.TileSize.W, lvl.TileSize.H, decoder.PixelFormatRGB)
+
+	for _, c := range [][2]int{{0, 0}, {2, 1}, {1, 0}} {
+		if err := s.imageStitchedTileInto(0, 0, c[0], c[1], dst); err != nil {
+			t.Fatalf("Into(%d,%d): %v", c[0], c[1], err)
+		}
+		want, err := s.imageStitchedTile(0, 0, c[0], c[1])
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !bytes.Equal(dst.Pix, want.Pix) {
+			t.Fatalf("reused dst for tile (%d,%d) does not match a fresh StitchedTile", c[0], c[1])
+		}
+	}
+}
+
+func TestStitchedTileIntoWrongDims(t *testing.T) {
+	s := &Slide{r: newFakeStitchReader(), readBudget: 64 << 20}
+	dst := decoder.NewImageFormat(50, 50, decoder.PixelFormatRGB) // not TileSize (100x100)
+	if err := s.imageStitchedTileInto(0, 0, 0, 0, dst); err == nil {
+		t.Fatal("want error for dst that is not TileSize")
+	}
+}
+
+func TestStitchedTileIntoNilDst(t *testing.T) {
+	s := &Slide{r: newFakeStitchReader(), readBudget: 64 << 20}
+	if err := s.imageStitchedTileInto(0, 0, 0, 0, nil); err == nil {
+		t.Fatal("want error for nil dst")
+	}
+}
+
+// Without a regionLayout, StitchedTileInto must delegate to DecodedTileInto and
+// produce the same pixels as DecodedTile.
+func TestStitchedTileIntoDelegatesWithoutLayout(t *testing.T) {
+	s := &Slide{r: &noLayout{newFakeStitchReader()}, readBudget: 64 << 20}
+	dst := decoder.NewImageFormat(100, 100, decoder.PixelFormatRGB)
+	if err := s.imageStitchedTileInto(0, 0, 1, 1, dst); err != nil {
+		t.Fatal(err)
+	}
+	want, err := s.imageDecodedTile(0, 0, 1, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(dst.Pix, want.Pix) {
+		t.Fatal("without regionLayout, StitchedTileInto must equal DecodedTile")
+	}
+}


### PR DESCRIPTION
## Summary

Follow-up to #76 (v0.50.0). Adds **`(*Level).StitchedTileInto(tx, ty, dst, opts...)`** — the allocation-free form of `StitchedTile`, for viewer loops that render many tiles and want to reuse one buffer.

- Composites the display tile into a caller-provided `dst` (must be exactly `TileSize`), in `dst`'s own pixel format, white-filling first.
- Delegates to `DecodedTileInto` for non-overlapping levels (mirrors `StitchedTile`'s total/uniform behavior).
- `StitchedTile` now allocates a `dst` and delegates to the shared `imageStitchedTileInto`, so both go through **one composite path** (no duplication).
- The composite is pinned to `dst.Format` (since `blitInto` requires src/dst share a format); the cache is keyed by that format. The caller's `opts` backing array is never mutated (full-slice-cap append).

Additive — no existing surface changes.

## Test Plan

- [x] `StitchedTileInto` byte-identical to `StitchedTile` for every canonical tile (fake reader)
- [x] Buffer-reuse: one `dst` across multiple tiles yields correct independent results (white-fill resets)
- [x] Wrong-dims `dst` → error; nil `dst` → error
- [x] No-layout delegation equals `DecodedTile`
- [x] v0.50 stitched/cache suite stays green (the `imageStitchedTile` refactor guard)
- [x] **BIF `StitchedTile` still byte-identical to `ReadRegion`** on Ventana-1 after the refactor
- [x] `go test . -race`, `go vet ./...`, `go build -tags nocgo ./...` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)