### PR TITLE
fix(#78): Level.Size/Downsample report true content extent (DP-BIF + IFE)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,9 @@ The single source of truth for "what was deferred and why" is
 front-page summary; the deferred file has the full reasoning,
 upstream references, and retirement audit per milestone.
 
-## [Unreleased]
+## [0.53.0] — 2026-06-24
+
+True-content-extent pyramid for DP-BIF + IFE (#78).
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,28 @@ The single source of truth for "what was deferred and why" is
 front-page summary; the deferred file has the full reasoning,
 upstream references, and retirement audit per milestone.
 
+## [Unreleased]
+
+### Fixed
+
+- **Pyramid `Level.Size`/`Downsample` now report true content extent for DP-BIF
+  and IFE** (#78). Previously these two formats reported a tile-grid-padded (BIF
+  reduced levels) or overlap-compacted-only-at-L0 extent, so the inter-level
+  scale wasn't exactly ~2× and a consumer building a pyramid from `Level.Size`
+  (e.g. `downsample = Size[0]/Size[i]`) mis-registered content across the L0/L1
+  boundary (BIF) or at coarse levels (IFE). DP-BIF reduced levels now derive from
+  the L0 stitched hull (floor-halving, matching bio-formats); IFE derives from the
+  per-layer `scale` anchored to `TILE_TABLE.x_extent/y_extent`. `Grid` (the stored
+  tile grid) is unchanged; tile bytes are byte-identical; the padded raster extent
+  remains recoverable as `Grid × TileSize`. **Legacy iScan BIF is unchanged** (its
+  reduced levels carry frame overlap — tracked in #80); the IFE Magnification/MPP
+  issue is separate (#81).
+
+  ⚠️ **Consumer note:** DP-BIF reduced-level and IFE `Level.Size`/`Downsample`
+  values change to the corrected ones. Consumers that built pyramids from the old
+  padded values (e.g. wsitools DZI output dims) will see shifted — now correct —
+  output.
+
 ## [0.52.0] — 2026-06-24
 
 Bare DZI reader (12th format) + shared Overlap>0 guard.

--- a/docs/superpowers/plans/2026-06-24-true-content-extent-pyramid.md
+++ b/docs/superpowers/plans/2026-06-24-true-content-extent-pyramid.md
@@ -1,0 +1,600 @@
+# True-Content-Extent Pyramid (DP-BIF + IFE) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `Level.Size`/`Downsample` the true content extent at every pyramid level for **DP-generation BIF** and **IFE**, so inter-level scale is exactly ~2×. BIF-DP derives reduced levels from the L0 stitched hull (floor-halving); IFE derives from the per-layer `scale` + `x_extent` anchor. Legacy-BIF is untouched (deferred to #80). Closes #78 for DP-BIF + IFE.
+
+**Architecture:** For BIF, one field (`levelImpl.size`) already drives `Level.Size`, `Downsample`, and (after a one-line alignment) `StitchedSize`; we override it for DP `i≥1`. For IFE, the per-level geometry is extracted into a pure helper and re-derived from layer scales. `Grid` (the stored tile grid) is unchanged in both; pixels still come from stored tiles; reads clip to the corrected `Size`.
+
+**Tech Stack:** Go 1.23+, `formats/bif`, `formats/ife`, `internal/dzi`-style pure helpers for testability. No cgo changes. Geometry-only — no tile bytes change.
+
+**Reference (read first):**
+- Design spec: `docs/superpowers/specs/2026-06-24-true-content-extent-pyramid-design.md` (esp. the **Consistency invariant**).
+- `formats/bif/bif.go:80-113` (level-build loop), `formats/bif/level.go:218-228` (`l.size` assignment), `:304-310` (`StitchedSize`), `formats/bif/classify.go:15-28` (`GenerationSpecCompliant` = DP).
+- `formats/ife/tiler.go:65-100` (level-build loop), `formats/ife/reader.go:69-78` (`LayerExtent{XTiles,YTiles,Scale}`), `:53-64` (`TileTable.XExtent/YExtent`).
+
+---
+
+## File Structure
+
+| File | Change |
+|---|---|
+| `formats/bif/bif.go` | Hoist `gen`; capture L0 hull; for DP `i≥1`, override `l.size` via `floorHalveSize`. |
+| `formats/bif/level.go` | `StitchedSize()` returns `l.size` (align to its `== Size()` doc); add `floorHalveSize` helper. |
+| `formats/bif/geometry_test.go` | Create: `floorHalveSize` unit test (fixture-free, `package bif`). |
+| `formats/ife/tiler.go` | Replace inline `Size`/`Downsample` with `ifeGeometry(...)` results. |
+| `formats/ife/geometry.go` | Create: pure `ifeGeometry` + `validPixelExtent`. |
+| `formats/ife/geometry_test.go` | Create: `ifeGeometry` unit tests (fixture-free, `package ife`). |
+| `pyramid_content_extent_test.go` | Create (root dir, `package opentile_test`): fixture-gated Ventana-1/OS-1/cervix geometry via `opentile.OpenFile` (public `StitchedTile`/`StitchedGrid` reachable, no internal-opener guessing). |
+| Parity/geometry snapshots | Update DP-BIF + IFE per-level `Size`/`Downsample` expectations (tile SHAs unchanged). |
+| `CHANGELOG.md` | `[Unreleased]` entry + consumer note. |
+
+---
+
+## Task 1: BIF — DP reduced-level content extent
+
+**Files:**
+- Modify: `formats/bif/bif.go`, `formats/bif/level.go`
+- Test: `formats/bif/geometry_test.go` (create; the `floorHalveSize` unit test only in this task)
+
+- [ ] **Step 1: Write the failing helper test**
+
+Create `formats/bif/geometry_test.go`:
+
+```go
+package bif
+
+import (
+	"testing"
+
+	opentile "github.com/wsilabs/opentile-go"
+)
+
+func TestFloorHalveSize(t *testing.T) {
+	// Ventana-1 DP hull → bio-formats sizeX/sizeY chain.
+	hull := opentile.Size{W: 23432, H: 21504}
+	wantW := []int{23432, 11716, 5858, 2929, 1464, 732, 366, 183}
+	wantH := []int{21504, 10752, 5376, 2688, 1344, 672, 336, 168}
+	for i := range wantW {
+		got := floorHalveSize(hull, i)
+		if got.W != wantW[i] || got.H != wantH[i] {
+			t.Errorf("floorHalveSize(hull,%d) = %dx%d, want %dx%d", i, got.W, got.H, wantW[i], wantH[i])
+		}
+	}
+}
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `go test ./formats/bif/ -run TestFloorHalveSize -count=1`
+Expected: FAIL — `undefined: floorHalveSize`.
+
+- [ ] **Step 3: Add the helper to level.go**
+
+In `formats/bif/level.go`, add (near the other package helpers, e.g. after `weightedAverageOverlap`):
+
+```go
+// floorHalveSize halves sz by 2, n times, with integer (floor) division —
+// reproducing bio-formats' per-resolution sizeX/sizeY chain for DP pyramids
+// (e.g. 23432 → 11716 → 5858 → 2929 → 1464 → …). n == 0 returns sz.
+func floorHalveSize(sz opentile.Size, n int) opentile.Size {
+	w, h := sz.W, sz.H
+	for k := 0; k < n; k++ {
+		w /= 2
+		h /= 2
+	}
+	return opentile.Size{W: w, H: h}
+}
+```
+
+- [ ] **Step 4: Run the helper test to verify it passes**
+
+Run: `go test ./formats/bif/ -run TestFloorHalveSize -count=1`
+Expected: PASS.
+
+- [ ] **Step 5: Align `StitchedSize()` to `l.size`**
+
+In `formats/bif/level.go`, replace the `StitchedSize` method (currently `:304-310`):
+
+```go
+// StitchedSize returns this level's stitched content extent (== Size()). It is
+// the single source of truth for the compositor's clip bounds; for DP reduced
+// levels this is the hull-derived content extent (#78). The stored-grid extent
+// (cols*tileW from the naive layout) is recoverable as Grid*TileSize.
+func (l *levelImpl) StitchedSize() (w, h int, ok bool) {
+	return l.size.W, l.size.H, true
+}
+```
+
+(This is behaviour-preserving today — `l.size` already equals `l.layout.Width/Height` at every level for real data — and makes `l.size` the one value `Level.Size` *and* `StitchedSize` both read, so the Task-Step-6 override fixes both at once. `TileOrigin`/`TilesIntersecting` keep using `l.layout` for placement, unchanged.)
+
+- [ ] **Step 6: Override `l.size` for DP reduced levels in the build loop**
+
+In `formats/bif/bif.go`, in `openFromTIFFFile`, hoist the generation and capture the L0 hull, then override DP `i≥1` sizes. Replace the loop header + the `if i == 0` block (`:84-93`):
+
+Current:
+```go
+	var l0Width int
+	for i, c := range levelIFDs {
+		l, err := newLevelImpl(i, c, iscan.ScanRes, scanWhite, classifyGeneration(iscan), encodeInfo, file.ReaderAt())
+		if err != nil {
+			return nil, err
+		}
+		if i == 0 {
+			levelZeroDepth = l.imageDepth
+			l0Width = l.size.W
+		}
+```
+
+New:
+```go
+	var l0Width int
+	var l0Hull opentile.Size
+	gen := classifyGeneration(iscan)
+	for i, c := range levelIFDs {
+		l, err := newLevelImpl(i, c, iscan.ScanRes, scanWhite, gen, encodeInfo, file.ReaderAt())
+		if err != nil {
+			return nil, err
+		}
+		if i == 0 {
+			levelZeroDepth = l.imageDepth
+			l0Width = l.size.W
+			l0Hull = l.size
+		} else if gen == GenerationSpecCompliant {
+			// #78: DP (spec-compliant / DP 200) reduced levels derive their
+			// content extent from the L0 stitched hull by floor-halving, not the
+			// padded IFD ImageWidth (which keeps the un-compacted frame-grid
+			// width). This drives Level.Size, Downsample, AND StitchedSize (all
+			// read l.size), so the pyramid's inter-level scale is exactly 2× and
+			// the compositor clips display tiles to true content. Legacy iScan is
+			// deliberately untouched — its reduced levels still carry frame
+			// overlap (GH #80) and need per-level stitching, not a Size change.
+			l.size = floorHalveSize(l0Hull, i)
+		}
+```
+
+Also update the later `gen:` field assignment (`:159`) to reuse the hoisted local: change `gen: classifyGeneration(iscan),` to `gen: gen,`.
+
+- [ ] **Step 7: Verify build + helper test + no other-format breakage at unit level**
+
+Run: `go build ./... && go vet ./formats/bif/`
+Expected: clean.
+
+Run: `go test ./formats/bif/ -run TestFloorHalveSize -count=1`
+Expected: PASS.
+
+Run: `go test ./formats/bif/ -count=1`
+Expected: PASS (existing non-fixture BIF unit tests; fixture-gated ones skip without `OPENTILE_TESTDIR`).
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add formats/bif/bif.go formats/bif/level.go formats/bif/geometry_test.go
+git commit -m "feat(bif): DP reduced levels report true content extent (Size/Downsample/StitchedSize from L0 hull) (#78)"
+```
+
+---
+
+## Task 2: BIF — fixture-gated geometry + consistency tests (root package)
+
+**Files:**
+- Create: `pyramid_content_extent_test.go` (root dir, **`package opentile_test`**)
+
+All fixture-gated geometry tests go through the public `opentile.OpenFile` in an external test package — the same pattern `bif_stitched_tile_test.go` uses — so there's no internal-opener guessing and `StitchedTile`/`StitchedGrid` (public `*Level` methods) are reachable. Ventana-1 + OS-1 are in the public wsi-fixtures BIF tar → these run in CI's integration job; they skip without `OPENTILE_TESTDIR`.
+
+- [ ] **Step 1: Create the BIF geometry test file**
+
+Create `pyramid_content_extent_test.go`:
+
+```go
+package opentile_test
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	opentile "github.com/wsilabs/opentile-go"
+	"github.com/wsilabs/opentile-go/decoder"
+	_ "github.com/wsilabs/opentile-go/decoder/all"
+	_ "github.com/wsilabs/opentile-go/formats/all"
+)
+
+// openFixture opens dir/<sub>/<name> via the public API, skipping when the
+// fixture corpus or the file is absent.
+func openFixture(t *testing.T, sub, name string) *opentile.Slide {
+	t.Helper()
+	dir := os.Getenv("OPENTILE_TESTDIR")
+	if dir == "" {
+		t.Skip("OPENTILE_TESTDIR not set")
+	}
+	p := filepath.Join(dir, sub, name)
+	if _, err := os.Stat(p); err != nil {
+		t.Skipf("fixture missing: %v", err)
+	}
+	s, err := opentile.OpenFile(p)
+	if err != nil {
+		t.Fatalf("open %s: %v", name, err)
+	}
+	return s
+}
+
+func ceilDivT(a, b int) int { return (a + b - 1) / b }
+
+func TestBIFVentanaContentExtent(t *testing.T) {
+	s := openFixture(t, "bif", "Ventana-1.bif")
+	defer s.Close()
+	wantW := []int{23432, 11716, 5858, 2929, 1464, 732, 366, 183}
+	wantH := []int{21504, 10752, 5376, 2688, 1344, 672, 336, 168}
+	levels := s.Levels()
+	if len(levels) != len(wantW) {
+		t.Fatalf("level count %d, want %d", len(levels), len(wantW))
+	}
+	for i, l := range levels {
+		if l.Size.W != wantW[i] || l.Size.H != wantH[i] {
+			t.Errorf("L%d Size = %dx%d, want %dx%d", i, l.Size.W, l.Size.H, wantW[i], wantH[i])
+		}
+		// Downsample is exactly 2^i (no longer 1.907 at L1).
+		want := float64(int(1) << uint(i))
+		if l.Downsample != want {
+			t.Errorf("L%d Downsample = %v, want %v", i, l.Downsample, want)
+		}
+		// StitchedGrid is the clean ceil partition of the (corrected) Size.
+		g := l.StitchedGrid()
+		if g.W != ceilDivT(l.Size.W, l.TileSize.W) || g.H != ceilDivT(l.Size.H, l.TileSize.H) {
+			t.Errorf("L%d StitchedGrid %v != ceil(Size %v / Tile %v)", i, g, l.Size, l.TileSize)
+		}
+	}
+}
+
+// Proves StitchedSize == Size functionally: at DP L1 the last display column
+// must clip overscan to white (only StitchedTile clips to StitchedSize, so if
+// StitchedSize still equalled the padded 12288 this column would show stored
+// overscan instead of white).
+func TestBIFVentanaStitchedTileClipsOverscan(t *testing.T) {
+	s := openFixture(t, "bif", "Ventana-1.bif")
+	defer s.Close()
+	l1, err := s.Level(1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	g := l1.StitchedGrid() // expect W = ceil(11716/1024) = 12
+	img, err := l1.StitchedTile(g.W-1, 0)
+	if errors.Is(err, decoder.ErrCodecUnavailable) {
+		t.Skip("decode unavailable (nocgo)")
+	}
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Last column origin = (g.W-1)*TileW = 11*1024 = 11264; content ends at
+	// Size.W = 11716, so local columns >= 11716-11264 = 452 are overscan → white.
+	contentCols := l1.Size.W - (g.W-1)*l1.TileSize.W // 452
+	bpp := 3
+	for _, y := range []int{0, img.Height / 2, img.Height - 1} {
+		for _, x := range []int{contentCols + 8, img.Width - 1} {
+			o := y*img.Stride + x*bpp
+			if img.Pix[o] != 0xFF || img.Pix[o+1] != 0xFF || img.Pix[o+2] != 0xFF {
+				t.Fatalf("overscan pixel (%d,%d) = %d,%d,%d, want white 255 (StitchedSize must == Size, not padded)",
+					x, y, img.Pix[o], img.Pix[o+1], img.Pix[o+2])
+			}
+		}
+	}
+}
+
+func TestBIFLegacySizeUnchanged(t *testing.T) {
+	s := openFixture(t, "bif", "OS-1.bif")
+	defer s.Close()
+	// Legacy iScan is deferred to #80 — its reduced-level Size must stay the raw
+	// (un-compacted) grid extent. Pin L0/L1 so this change can't silently alter
+	// legacy. (105818 hull at L0; 59392 = 58*1024 raw grid at L1.)
+	levels := s.Levels()
+	if levels[0].Size.W != 105818 {
+		t.Errorf("OS-1 L0 Size.W = %d, want 105818 (unchanged hull)", levels[0].Size.W)
+	}
+	if levels[1].Size.W != 59392 {
+		t.Errorf("OS-1 L1 Size.W = %d, want 59392 (raw grid, legacy untouched — see #80)", levels[1].Size.W)
+	}
+}
+```
+
+- [ ] **Step 2: Run the fixture-gated tests (locally, with fixtures)**
+
+Run: `OPENTILE_TESTDIR="$PWD/sample_files" go test . -run 'TestBIFVentana|TestBIFLegacy' -count=1 -v`
+Expected: PASS (Ventana-1 chain + Downsample + StitchedGrid + StitchedTile overscan-white; OS-1 legacy unchanged). If `sample_files/bif/*` absent, SKIP — report which.
+
+Also confirm it builds under nocgo (the file is in the root package, which the nocgo `test` job compiles): `go vet -tags nocgo .` — clean.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add pyramid_content_extent_test.go
+git commit -m "test(bif): Ventana-1 content-extent chain + Downsample + StitchedGrid/StitchedTile overscan consistency; OS-1 legacy pinned unchanged"
+```
+
+---
+
+## Task 3: IFE — scale-derived content extent
+
+**Files:**
+- Create: `formats/ife/geometry.go`, `formats/ife/geometry_test.go`
+- Modify: `formats/ife/tiler.go`
+
+- [ ] **Step 1: Write the failing helper test**
+
+Create `formats/ife/geometry_test.go`:
+
+```go
+package ife
+
+import (
+	"testing"
+
+	opentile "github.com/wsilabs/opentile-go"
+)
+
+func TestIFEGeometryScaleRatios(t *testing.T) {
+	// 3 layers, native-first: scales 4,2,1 → downsamples 1,2,4.
+	api := []LayerExtent{
+		{XTiles: 8, YTiles: 6, Scale: 4},
+		{XTiles: 4, YTiles: 3, Scale: 2},
+		{XTiles: 2, YTiles: 2, Scale: 1},
+	}
+	// x_extent valid pixels (not a multiple of 256): in ((8-1)*256, 8*256] = (1792,2048].
+	tt := TileTable{XExtent: 1900, YExtent: 1400}
+	sizes, downs := ifeGeometry(api, tt)
+	if sizes[0] != (opentile.Size{W: 1900, H: 1400}) {
+		t.Fatalf("L0 size = %v, want 1900x1400 (x_extent anchor)", sizes[0])
+	}
+	wantDown := []float64{1, 2, 4}
+	for i := range downs {
+		if downs[i] != wantDown[i] {
+			t.Errorf("L%d downsample = %v, want %v", i, downs[i], wantDown[i])
+		}
+	}
+	// Exact 2x ratios (round of 1900/2=950, /4=475).
+	if sizes[1] != (opentile.Size{W: 950, H: 700}) || sizes[2] != (opentile.Size{W: 475, H: 350}) {
+		t.Fatalf("scaled sizes = %v %v, want 950x700 475x350", sizes[1], sizes[2])
+	}
+}
+
+func TestIFEGeometryInvalidExtentFallsBack(t *testing.T) {
+	api := []LayerExtent{
+		{XTiles: 8, YTiles: 6, Scale: 2},
+		{XTiles: 4, YTiles: 3, Scale: 1},
+	}
+	// x_extent carries TILE COUNTS (cervix non-conformance): 8 is not in (1792,2048].
+	tt := TileTable{XExtent: 8, YExtent: 6}
+	sizes, downs := ifeGeometry(api, tt)
+	// Falls back to padded L0 (8*256 x 6*256); ratios still exact.
+	if sizes[0] != (opentile.Size{W: 2048, H: 1536}) {
+		t.Fatalf("L0 size = %v, want padded 2048x1536 fallback", sizes[0])
+	}
+	if downs[1] != 2 || sizes[1] != (opentile.Size{W: 1024, H: 768}) {
+		t.Fatalf("L1 down=%v size=%v, want 2 / 1024x768", downs[1], sizes[1])
+	}
+}
+
+func TestValidPixelExtent(t *testing.T) {
+	if !validPixelExtent(1900, 8) { // (1792,2048]
+		t.Error("1900 with 8 tiles should be valid pixels")
+	}
+	if validPixelExtent(8, 8) { // tile-count, not pixels
+		t.Error("8 with 8 tiles should be invalid (tile count)")
+	}
+	if validPixelExtent(2048, 8) == false { // exact multiple is valid
+		t.Error("2048 with 8 tiles should be valid")
+	}
+	if validPixelExtent(1792, 8) { // == (tiles-1)*256, boundary excluded
+		t.Error("1792 with 8 tiles should be invalid")
+	}
+}
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `go test ./formats/ife/ -run 'TestIFEGeometry|TestValidPixelExtent' -count=1`
+Expected: FAIL — `undefined: ifeGeometry` / `validPixelExtent`.
+
+- [ ] **Step 3: Create the geometry helper**
+
+Create `formats/ife/geometry.go`:
+
+```go
+package ife
+
+import (
+	"math"
+
+	opentile "github.com/wsilabs/opentile-go"
+)
+
+// ifeGeometry computes per-API-level content Size and Downsample from the layer
+// scales and the L0 content extent. api is native-first (api[0] = finest =
+// max scale). The spec's downsample is max_scale/scale; the content extent at
+// each level is L0_content / downsample, rounded. L0 content comes from
+// TileTable.x_extent/y_extent when those are valid pixel dimensions, else the
+// padded XTiles*256 grid (the cervix fixture stores tile counts there).
+func ifeGeometry(api []LayerExtent, tt TileTable) (sizes []opentile.Size, downs []float64) {
+	n := len(api)
+	sizes = make([]opentile.Size, n)
+	downs = make([]float64, n)
+	if n == 0 {
+		return sizes, downs
+	}
+	maxScale := float64(api[0].Scale)
+
+	size0 := opentile.Size{
+		W: int(api[0].XTiles) * TileSidePixels,
+		H: int(api[0].YTiles) * TileSidePixels,
+	}
+	if validPixelExtent(int(tt.XExtent), int(api[0].XTiles)) &&
+		validPixelExtent(int(tt.YExtent), int(api[0].YTiles)) {
+		size0 = opentile.Size{W: int(tt.XExtent), H: int(tt.YExtent)}
+	}
+
+	for i := range api {
+		ds := maxScale / float64(api[i].Scale)
+		downs[i] = ds
+		sizes[i] = opentile.Size{
+			W: int(math.Round(float64(size0.W) / ds)),
+			H: int(math.Round(float64(size0.H) / ds)),
+		}
+	}
+	return sizes, downs
+}
+
+// validPixelExtent reports whether ext is a plausible pixel dimension for a
+// tile grid of `tiles` columns/rows: it must lie in ((tiles-1)*256, tiles*256].
+// Tile COUNTS (e.g. cervix's x_extent) fail this test, so the caller falls back
+// to the padded grid base.
+func validPixelExtent(ext, tiles int) bool {
+	if tiles <= 0 {
+		return false
+	}
+	return ext > (tiles-1)*TileSidePixels && ext <= tiles*TileSidePixels
+}
+```
+
+- [ ] **Step 4: Run the helper tests to verify they pass**
+
+Run: `go test ./formats/ife/ -run 'TestIFEGeometry|TestValidPixelExtent' -count=1`
+Expected: PASS.
+
+- [ ] **Step 5: Rewire `tiler.go` to use the helper**
+
+In `formats/ife/tiler.go`, compute geometry once before the level loop and use it. Replace `l0Width` (`:69-70`) and the per-level `Size`/`Downsample` (`:92,96`):
+
+After `apiOrder` is built (and `tt` is in scope), add before the loop:
+```go
+	sizes, downs := ifeGeometry(apiOrder, tt)
+```
+Remove the now-unused `l0FileIdx`/`l0Width` lines if they become unused. Inside the loop, keep `ext := fileOrder[fi]` (still used for `Grid` and the tile-count walk), and set the level fields from the helper:
+```go
+		valueLevels[i] = opentile.Level{
+			Index:        i,
+			PyramidIndex: i,
+			Size:         sizes[i],
+			TileSize:     opentile.Size{W: TileSidePixels, H: TileSidePixels},
+			Grid:         opentile.Size{W: int(ext.XTiles), H: int(ext.YTiles)},
+			Compression:  compression,
+			Downsample:   downs[i],
+		}
+```
+Delete the now-unused `levelW := int(ext.XTiles) * TileSidePixels` line (Grid uses `ext.XTiles` directly). If `l0Width`/`l0FileIdx` are now unused, remove them (the compiler will flag).
+
+- [ ] **Step 6: Verify build + unit tests + IFE package suite**
+
+Run: `go build ./... && go vet ./formats/ife/`
+Expected: clean (no unused-variable errors — remove `l0Width`/`l0FileIdx`/`levelW` if flagged).
+
+Run: `go test ./formats/ife/ -count=1`
+Expected: PASS (helper tests + existing IFE unit tests; fixture-gated ones skip).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add formats/ife/geometry.go formats/ife/geometry_test.go formats/ife/tiler.go
+git commit -m "feat(ife): Level.Size/Downsample from per-layer scale + x_extent anchor (true content extent) (#78)"
+```
+
+---
+
+## Task 4: IFE fixture test, snapshots, docs, verification
+
+**Files:**
+- Modify: `pyramid_content_extent_test.go` (append the cervix ratio test — root package, public API), parity/geometry snapshots, `CHANGELOG.md`
+
+- [ ] **Step 1: Add the cervix ratio test (local-gated, root package)**
+
+Append to `pyramid_content_extent_test.go` (the `package opentile_test` file from Task 2; reuses its `openFixture` helper). cervix is local-only (not in CI fixtures) so it skips in CI:
+
+```go
+func TestIFECervixRatiosConsistent(t *testing.T) {
+	s := openFixture(t, "ife", "cervix_2x_jpeg.iris")
+	defer s.Close()
+	levels := s.Levels()
+	for i := 1; i < len(levels); i++ {
+		rw := float64(levels[i-1].Size.W) / float64(levels[i].Size.W)
+		rh := float64(levels[i-1].Size.H) / float64(levels[i].Size.H)
+		// Drift is gone: every adjacent ratio is ~2 (the bug had 1.5–1.99 at
+		// coarse levels). Tolerate <=1px rounding => ratio within [1.95, 2.05].
+		if rw < 1.95 || rw > 2.05 || rh < 1.95 || rh > 2.05 {
+			t.Errorf("L%d->L%d ratio = %.4f/%.4f, want ~2.0", i-1, i, rw, rh)
+		}
+		// Inter-level downsample is exact-2 (the spec's max_scale/scale).
+		if d := levels[i].Downsample / levels[i-1].Downsample; d < 1.95 || d > 2.05 {
+			t.Errorf("L%d/L%d Downsample ratio = %.4f, want ~2.0", i, i-1, d)
+		}
+	}
+}
+```
+
+- [ ] **Step 2: Update parity / geometry snapshots**
+
+DP-BIF (Ventana-1) and IFE per-level `Size`/`Downsample` values change (tile SHAs do **not**). Find and update any committed expectations:
+
+```bash
+grep -rIl "12288\|Downsample" tests/ formats/bif formats/ife 2>/dev/null | grep -iE "geometry|parity|golden|snapshot|expect" || true
+```
+
+Run the parity/geometry suites and update the BIF-DP + IFE numbers (and only those) where they assert per-level dims; confirm tile-byte SHAs are unchanged:
+
+Run: `OPENTILE_TESTDIR="$PWD/sample_files" go test ./tests/... -run 'Geometry|Parity' -count=1` (and `./tests/parity/...` if present).
+Expected: BIF-DP + IFE dim expectations need updating to the content-extent values; **legacy-BIF and the other 9 formats unchanged**. Update only the changed expectations; if a snapshot regen command exists (e.g. a `-generate` flag like `tests` uses), prefer it but diff the output to confirm only BIF-DP/IFE dims moved.
+
+- [ ] **Step 3: CHANGELOG entry**
+
+In `CHANGELOG.md`, insert above the top release section:
+
+```markdown
+## [Unreleased]
+
+### Fixed
+
+- **Pyramid `Level.Size`/`Downsample` now report true content extent for DP-BIF
+  and IFE** (#78). Previously these two formats reported a tile-grid-padded (BIF
+  reduced levels) or overlap-compacted-only-at-L0 extent, so the inter-level
+  scale wasn't exactly 2× and a consumer building a pyramid from `Level.Size`
+  (e.g. `downsample = Size[0]/Size[i]`) mis-registered content across the L0/L1
+  boundary (BIF) or at coarse levels (IFE). DP-BIF reduced levels now derive from
+  the L0 stitched hull (floor-halving, matching bio-formats); IFE derives from the
+  per-layer `scale` anchored to `TILE_TABLE.x_extent/y_extent`. `Grid` (the stored
+  tile grid) is unchanged; pixels are unchanged (tile bytes byte-identical); the
+  padded raster extent remains recoverable as `Grid × TileSize`. **Legacy iScan
+  BIF is unchanged** (its reduced levels carry frame overlap — tracked in #80);
+  the IFE Magnification/MPP issue is separate (#81).
+
+  ⚠️ **Consumer note:** DP-BIF reduced-level and IFE `Level.Size`/`Downsample`
+  values change to the corrected ones. Consumers that built pyramids from the old
+  padded values (e.g. wsitools DZI output dims) will see shifted — now correct —
+  output.
+```
+
+- [ ] **Step 4: Full verification**
+
+macOS linker warnings (`ld: warning: ignoring duplicate libraries`) are pre-existing noise.
+- `go vet ./...` — clean.
+- `go build ./... && go build -tags nocgo ./...` — both clean.
+- `go test ./... -race -count=1` — PASS (note: synthetic helper tests are fixture-free; new fixture-gated tests skip without `OPENTILE_TESTDIR`).
+- `OPENTILE_TESTDIR="$PWD/sample_files" go test . ./formats/bif/ ./formats/ife/ ./tests/... -count=1` — PASS: Ventana-1 content chain (root `pyramid_content_extent_test.go`), OS-1 legacy unchanged, IFE cervix ratios ~2×, parity (other formats byte-identical, BIF-DP+IFE dims updated).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add pyramid_content_extent_test.go CHANGELOG.md tests/
+git commit -m "test(ife): cervix ratio consistency; update DP-BIF+IFE geometry snapshots; CHANGELOG (#78)"
+```
+
+---
+
+## Notes for the executor
+
+- **Geometry-only:** no tile bytes change for any format. If a *tile-byte* SHA snapshot moves, something is wrong — stop and investigate.
+- **Legacy BIF is untouched by design** — the `gen == GenerationSpecCompliant` gate is the load-bearing line. `TestBIFLegacySizeUnchanged` pins it; if it fails, the gate is wrong (do not "fix" the test).
+- **`StitchedSize == Size` is the consistency invariant** (the spec's load-bearing detail). Both must read `l.size` for BIF; the Task-1 Step-5 change is what guarantees it.
+- **Fixture availability:** Ventana-1 + OS-1 are in the public wsi-fixtures BIF tar → BIF geometry tests run in CI. cervix IFE is **local-only** → the cervix test skips in CI; the `ifeGeometry` unit tests are the CI-safe IFE coverage.
+- **Consumer coordination:** flag the wsitools/openscope `Size` change (CHANGELOG ⚠️) — not in our CI.
+- **Version:** ships as the next minor (additive-in-spirit, but a behavior change to two formats' `Size`); per cadence, **v0.53.0** after CI green. (It's a fix, not a new API; MINOR is appropriate given the visible `Size` change.)
+- **Out of scope:** legacy-BIF reduced levels (#80), IFE MPP (#81), the other 10 formats.
+```

--- a/docs/superpowers/specs/2026-06-24-true-content-extent-pyramid-design.md
+++ b/docs/superpowers/specs/2026-06-24-true-content-extent-pyramid-design.md
@@ -95,13 +95,38 @@ distinguishes DP from legacy. Extend the L0 derivation to the reduced levels —
   overlap → the padded IFD height already equalled `hull/2^i`).
 - `Downsample[i]` becomes exact `2^i` (it is computed from `Size`:
   `l0Hull.W / Size[i].W`).
+- **The same content extent drives the `regionLayout` capability**, not just the
+  `Level.Size` metadata (see the **Consistency invariant** below). The per-level
+  `StitchedSize(level)` returned to the region/`StitchedTile`/`ScaledStrips`
+  compositing path must equal the corrected `Level.Size`, computed from one
+  source. (Today both happen to equal the padded grid at L1+; correcting only
+  `Level.Size` would desync them.)
 - **Legacy** (`buildLegacyLayout` pyramids) and **non-overlapping** BIF: **no
-  change** — `Size[i]` keeps its current value. Legacy is gated behind #80.
+  change** — `Size[i]` and `StitchedSize(level)` keep their current values.
+  Legacy is gated behind #80.
 - `Grid` is unchanged (the raw stored grid). DP L1+ are non-overlapping, so
   `Grid == ceil(Size/TileSize)` (Ventana-1 L1: `ceil(11716/1024)=12=Grid`) →
   `Overlapping` stays **false** and the contract holds. Reads place tiles at
   `col·tile` and clip to `Size`; since DP L1+ don't overlap, the content is the
   top-left `Size` region and clipping is correct.
+
+#### Consistency invariant (BIF)
+
+For BIF, `Level.Size[i]`, `regionLayout.StitchedSize(i)`, and
+`StitchedGrid() = ceil(Size/TileSize)` are **derived from one per-level
+content-extent value** and must agree. This guarantees the four read surfaces are
+mutually consistent at every level:
+
+- `ReadRegion` clips to `min(Level.Size, StitchedSize)` — consistent once equal.
+- **`StitchedTile` clips to `StitchedSize(level)` only** (it does not consult
+  `Level.Size`), so `StitchedSize` *must* be the content extent — otherwise a
+  display tile composites overscan past where `Level.Size`/`StitchedGrid` say
+  content ends. For the partial last column this yields `content + white-fill`,
+  matching openslide/bio-formats (which never return the overscan).
+- `ReadRegionScaled` / `ScaledStrips` inherit `StitchedSize` for their bounds.
+
+This is the load-bearing detail the v0.46 stitch already honors at L0 (where
+`Level.Size == StitchedSize == hull`); the fix extends that equality to DP L1+.
 
 ### IFE (all levels)
 
@@ -146,7 +171,7 @@ registration-relevant magnitude.
 
 | File | Change |
 |---|---|
-| `formats/bif/` (level build — `bif.go` / `level.go`, TBD in plan) | For DP pyramids, derive L1+ `Size` (and thus `Downsample`) by iterative floor-halving from the L0 hull, instead of the padded IFD `ImageWidth/Length`. Legacy/non-overlapping untouched. |
+| `formats/bif/` (level build + `levelImpl.StitchedSize`, `bif.go`/`level.go`) | For DP pyramids, compute one per-level content extent (iterative floor-halving from the L0 hull) and use it for **both** `Level.Size`/`Downsample` **and** the `levelImpl`'s `StitchedSize(level)` (the `regionLayout` value). Legacy/non-overlapping untouched. |
 | `formats/ife/tiler.go:70-96` | Replace `Size = XTiles·256` / `Downsample = l0Width/levelW` with `scale`-derived `Downsample = max_scale/scale` + `Size = round(Size0/Downsample)`, anchoring `Size0` to `x_extent/y_extent` when those pass the pixel-validity test. |
 | `formats/ife/reader.go` | Already parses `Scale` + `XExtent/YExtent`; possibly expose `max_scale` / a small helper. No new parsing. |
 | Tests (BIF + IFE) | New per-level `Size`/`Downsample` assertions; regression guards (see below). |
@@ -184,6 +209,11 @@ registration-relevant magnitude.
   isn't a local fixture).
 - **Cross-format regression:** `TestSlideParity` byte-identical for the other 10
   formats (their `Size`/`Downsample` are untouched).
+- **BIF consistency invariant (fixture-gated, Ventana-1):** at every level
+  `Level.Size == regionLayout StitchedSize == ` the value `StitchedGrid` is
+  derived from; and `StitchedTile` over `StitchedGrid()` at DP L1 returns a last
+  partial column that is `content + white-fill` (clipped to the corrected
+  extent), not overscan. Guards the desync this review caught.
 - **Read correctness:** `ReadRegion`/`DecodedTile` at DP L1 and an IFE coarse
   level still return correct content after the `Size` clip.
 

--- a/docs/superpowers/specs/2026-06-24-true-content-extent-pyramid-design.md
+++ b/docs/superpowers/specs/2026-06-24-true-content-extent-pyramid-design.md
@@ -1,0 +1,216 @@
+# True-Content-Extent Pyramid (`Level.Size`/`Downsample`) — Design
+
+**Status:** Draft for review (no code written)
+**Date:** 2026-06-24
+**Closes (partial):** #78 — for DP-BIF and IFE. Legacy-BIF is deferred to #80
+(coupled to per-level stitching); the IFE Magnification/MPP-from-wrong-level bug
+is separate (#81).
+
+---
+
+## Goal
+
+Make `Level.Size` report the **true content extent** at every pyramid level for
+the two formats that currently report a tile-grid-padded (or overlap-compacted-
+only-at-L0) extent — **DP-generation BIF** and **IFE** — so the pyramid's
+inter-level scale is exactly ~2× and a consumer can derive
+`downsample = Size[0]/Size[i]` and traverse levels without per-level offset/scale
+correction. `Downsample` is corrected in lockstep. Pixels still come from the
+stored tiles; only the *geometry* is corrected.
+
+## Background
+
+`Level.Size` is documented as "the pixel dimensions of this level." For 10 of the
+12 formats it already equals the true content extent (TIFF readers source it from
+the per-level IFD `ImageWidth/Length`, which is content; tiles pad internally).
+**BIF and IFE are the two deviations**, each sourcing `Size` from a padded/derived
+grid extent instead:
+
+- **BIF** — its per-level IFD `ImageWidth` is the *padded frame grid*
+  (Ventana-1 L1 = `12×1024 = 12288`, not the `11716` content). v0.46 overrides
+  this with the derived stitched hull **only at L0**; L1+ fall through to the
+  padded tag. Result: the L0→L1 ratio is off by the overlap fraction (Ventana-1
+  `23432/12288 = 1.907`), and the pyramid mixes two semantics (L0 content,
+  L1+ grid) — an internal self-contradiction.
+- **IFE** — no TIFF IFDs; the reader *computes* `Size = XTiles·256` (the grid)
+  per level, and the ceil-to-tile padding doesn't halve cleanly, so ratios drift
+  off 2× at coarse levels (e.g. a level reporting `512` whose content is `~346`).
+
+The unifying root: **`Size` sourced from a padded extent, not true content.**
+
+### Downstream effect
+
+A consumer that builds a pyramid from `Size` (the natural thing) gets a
+registration error that grows toward the bottom-right when crossing levels
+(top-left stays anchored). Observed in openscope: Ventana-1 shifts horizontally
+at the 20×→40× (L1→L0) step; IFE drifts at coarse levels. Per-tile pixel output is
+correct — only cross-level `Size` math is wrong.
+
+### Phase-0 oracle probe (what decided this design)
+
+- **Ground truth = `hull/2^i` content extent**, confirmed by **both** reference
+  readers: bio-formats `sizeX` for Ventana-1 DP (`23432→11716→5858→…`, floor-
+  halving) and **both** bio-formats and openslide for OS-1 legacy
+  (`105817/105813 → 52908/52907 → …`, clean 2.0). The other 10 formats already
+  do this — so this is the library's own convention, not a new definition.
+- **Both oracles fully composite every level internally** and expose only a
+  content-extent pyramid with exact downsamples; the consumer never sees a frame
+  grid or overlap at any level. That is the target behavior.
+- **Rounding differs between the references** (bio-formats floors, openslide
+  rounds/ceils — ≤1px at odd levels). "Within rounding" is literally how the two
+  oracles differ from each other.
+- **Legacy-BIF L1+ tiles genuinely overlap** — pixel-confirmed: an adjacent-tile
+  match-offset sweep found a near-exact overlap band at OS-1 L1 (~55px, min
+  MAD 4.82) with controls validating the method (OS-1 L0 positive: ~115px,
+  MAD 6.25; Ventana-1 L1 negative: none). So legacy reduced levels preserve the
+  overlapping frame structure and need per-level stitching (#80) — they are
+  **out of scope here** (a Size-only change would give the right ratio but
+  doubled/shifted pixels). DP-BIF L1+ do **not** overlap (the 1-column L0 overlap
+  vanishes at half-res), and IFE is non-overlapping — both are safe to fix with
+  geometry only.
+
+## Scope
+
+In: **DP-generation BIF** (`Size`/`Downsample` for L1+) and **IFE** (all levels).
+Out: legacy-BIF (→ #80), IFE Magnification/MPP (→ #81), any non-BIF/IFE format
+(must stay byte-identical).
+
+## Design
+
+**Principle:** `Level.Size` = true content extent at every level; `Downsample`
+exact; `Grid` stays the raw **stored** tile grid; **pixels are still read from the
+stored tiles**; region/`StitchedTile`/`DecodedTile` reads clip to the corrected
+`Size`. The padded raster extent remains recoverable as `Grid × TileSize`.
+
+### BIF (DP generation only)
+
+The BIF reader already derives the stitched hull at L0 (`buildDPLayout`) and
+distinguishes DP from legacy. Extend the L0 derivation to the reduced levels —
+**for a DP-stitched pyramid only**:
+
+- `Size[i]` for `i ≥ 1` is derived by **iterative floor-halving from the L0 hull**:
+  `Size[i] = floor(Size[i-1] / 2)` per axis, seeded by `Size[0] =` the L0 stitched
+  hull. This reproduces the bio-formats `sizeX` chain exactly
+  (`23432,11716,5858,2929,1464,732,366,183`); DP heights are unchanged (no Y
+  overlap → the padded IFD height already equalled `hull/2^i`).
+- `Downsample[i]` becomes exact `2^i` (it is computed from `Size`:
+  `l0Hull.W / Size[i].W`).
+- **Legacy** (`buildLegacyLayout` pyramids) and **non-overlapping** BIF: **no
+  change** — `Size[i]` keeps its current value. Legacy is gated behind #80.
+- `Grid` is unchanged (the raw stored grid). DP L1+ are non-overlapping, so
+  `Grid == ceil(Size/TileSize)` (Ventana-1 L1: `ceil(11716/1024)=12=Grid`) →
+  `Overlapping` stays **false** and the contract holds. Reads place tiles at
+  `col·tile` and clip to `Size`; since DP L1+ don't overlap, the content is the
+  top-left `Size` region and clipping is correct.
+
+### IFE (all levels)
+
+IFE carries the exact geometry in-file: `TILE_TABLE.x_extent/y_extent` ("image
+width/height in pixels at top resolution layer", spec §TILE_TABLE) and a per-layer
+`LayerExtent.Scale` with the spec's downsample formula `downsample = max_scale /
+scale`. Replace the padded `XTiles·256` `Size` with a scale-derived extent:
+
+- **Always (fixes the drift, even on non-conformant files):** derive the pyramid
+  from the per-layer `scale`:
+  - `Downsample[i] = max_scale / scale[i]` (spec formula; `max_scale` = finest =
+    L0).
+  - `Size[i] = round(Size[0] / Downsample[i])` per axis.
+- **Anchor L0 to true content when available:** if `x_extent/y_extent` are valid
+  pixel dimensions, set `Size[0] = (x_extent, y_extent)`; otherwise keep the
+  current `Size[0] = (XTiles[0]·256, YTiles[0]·256)` padded base.
+  - **Validity test:** `x_extent` is pixels iff it lies in
+    `((XTiles[0]-1)·256, XTiles[0]·256]` (content fits the L0 tile grid with a
+    partial last tile). The cervix fixture stores *tile counts* there
+    (`reader.go:63` note), which fails this test → falls back to the padded base
+    but still gets exact *ratios* from `scale`. GT450 stores pixels → fully
+    content-exact.
+- IFE is non-overlapping, so `Grid = XTiles = ceil(content/256)` → `Overlapping`
+  stays false; naive tile placement is already correct; reads clip to the
+  corrected `Size`.
+
+### API representation
+
+Redefine `Level.Size` / `Level.Downsample` **in place** (no new field). This is
+the library's existing convention (the value becomes correct, matching the other
+10 formats and both reference readers); the old padded value was a bug. The padded
+raster extent is still exactly `Grid × TileSize` for any consumer that needs it.
+
+### Rounding
+
+Match each format's reference: **BIF — floor-halving** (bio-formats, the sole DP
+oracle); **IFE — `round`** of the scale-derived extent (the spec's
+`max_scale/scale` formula). Documented; differences are ≤1px and below
+registration-relevant magnitude.
+
+## Components / files
+
+| File | Change |
+|---|---|
+| `formats/bif/` (level build — `bif.go` / `level.go`, TBD in plan) | For DP pyramids, derive L1+ `Size` (and thus `Downsample`) by iterative floor-halving from the L0 hull, instead of the padded IFD `ImageWidth/Length`. Legacy/non-overlapping untouched. |
+| `formats/ife/tiler.go:70-96` | Replace `Size = XTiles·256` / `Downsample = l0Width/levelW` with `scale`-derived `Downsample = max_scale/scale` + `Size = round(Size0/Downsample)`, anchoring `Size0` to `x_extent/y_extent` when those pass the pixel-validity test. |
+| `formats/ife/reader.go` | Already parses `Scale` + `XExtent/YExtent`; possibly expose `max_scale` / a small helper. No new parsing. |
+| Tests (BIF + IFE) | New per-level `Size`/`Downsample` assertions; regression guards (see below). |
+| `docs/`, `CHANGELOG.md` | Document the corrected `Size` semantics + the consumer note. |
+
+## Error handling / edge cases
+
+- **DP single-tile / non-overlapping levels:** `Size` already correct → no
+  derivation applied.
+- **IFE `scale` strictly increasing** is already validated at parse
+  (`reader.go`); `max_scale` is the last (finest) entry.
+- **IFE non-conformant `x_extent`** (cervix tile-counts): pixel-validity test
+  fails → padded L0 base, exact ratios preserved.
+- **Reads at corrected `Size`:** DP L1+ and IFE are non-overlapping, so the
+  content is the top-left `Size` region of the stored grid; clipping is correct
+  (the dropped pixels are padding/overscan). Verified by the non-overlap pixel
+  controls.
+- **Legacy BIF:** explicitly unchanged — a regression test pins legacy `Size` to
+  its current value so this change cannot silently alter it.
+
+## Testing strategy
+
+- **BIF DP (fixture-gated, Ventana-1):** assert per-level `Size` equals the
+  bio-formats `sizeX` chain (`23432,11716,5858,…`) and heights
+  (`21504,10752,…`); `Downsample[i] == 2^i` (exact); L0 unchanged.
+- **BIF legacy regression (fixture-gated, OS-1):** assert per-level `Size` is
+  **unchanged** from current (raw grid) — proves legacy is untouched (deferred to
+  #80).
+- **IFE ratios (cervix, local):** assert `Size[i-1]/Size[i] ≈ 2` within rounding
+  and `Downsample[i] == max_scale/scale[i]`; the drift (current coarse-level
+  ratios ≠ 2) is gone.
+- **IFE x_extent anchor (synthetic unit test):** construct `LAYER_EXTENTS` +
+  `TILE_TABLE` with a pixel `x_extent` not divisible by 256 and assert
+  `Size[0] == x_extent` and exact downsample chain (GT450 behavior, since GT450
+  isn't a local fixture).
+- **Cross-format regression:** `TestSlideParity` byte-identical for the other 10
+  formats (their `Size`/`Downsample` are untouched).
+- **Read correctness:** `ReadRegion`/`DecodedTile` at DP L1 and an IFE coarse
+  level still return correct content after the `Size` clip.
+
+## Consumer impact
+
+DP-BIF L1+ and IFE `Size`/`Downsample` values **change** (to correct ones).
+Downstream consumers that built pyramids from the old padded values — notably
+**wsitools** (DZI/output dims) — will see shifted output (a fix, but byte-
+changing). wsitools/openscope are not in opentile-go CI, so this needs explicit
+consumer coordination per the standing lesson. openscope is the beneficiary
+(its zoom registration is fixed for DP-BIF + IFE).
+
+## Out of scope / deferred
+
+- **Legacy-BIF reduced-level geometry** → blocked on #80 (per-level stitching;
+  pixel-confirmed overlap). A Size-only change there would mis-place pixels.
+- **IFE Magnification/MPP-from-wrong-level** → #81 (separate metadata bug).
+- Any change to `Grid`, tile placement, or the 10 already-correct formats.
+
+## Open questions
+
+1. **BIF derivation seat:** confirm the exact build site (`formats/bif/bif.go`
+   level construction vs `level.go`) and that the L0 hull is available before L1+
+   `Size` is assigned (compute L0 first, then derive). Resolved in the plan.
+2. **IFE `Downsample` field type:** current `Downsample` is `float64`;
+   `max_scale/scale` is exact-enough as `float64`. Confirm no precision surprise
+   vs the integer-power expectation (round for display only, keep float).
+3. **Legacy regression-pin fixture availability in CI:** OS-1 is in the public
+   wsi-fixtures corpus (BIF tar) — confirm the legacy-unchanged test runs in CI,
+   else gate it local-only.

--- a/docs/superpowers/specs/2026-06-24-true-content-extent-pyramid-design.md
+++ b/docs/superpowers/specs/2026-06-24-true-content-extent-pyramid-design.md
@@ -93,8 +93,15 @@ distinguishes DP from legacy. Extend the L0 derivation to the reduced levels —
   hull. This reproduces the bio-formats `sizeX` chain exactly
   (`23432,11716,5858,2929,1464,732,366,183`); DP heights are unchanged (no Y
   overlap → the padded IFD height already equalled `hull/2^i`).
-- `Downsample[i]` becomes exact `2^i` (it is computed from `Size`:
-  `l0Hull.W / Size[i].W`).
+- `Downsample[i]` is the literal `l0Hull.W / Size[i].W` ratio (self-consistent
+  with `Size`, the openslide convention — `level_downsamples` reports the literal
+  ratio, not a forced power of two). Because `Size` is floor-halved, L1–L3 are
+  exactly `2/4/8` (when the hull divides evenly) and L4+ drift `<0.05%`
+  (`23432/1464 = 16.005`). This is *within rounding* of `2^i` — the #78 goal (the
+  bug had L1 at `1.907`) — and keeping `Downsample == Size0/Size_i` is required
+  for `ReadRegionScaled`'s coordinate mapping to stay accurate. Do **not** force
+  exact `2^i`, which would desync `Downsample` from the actual content-raster
+  ratio.
 - **The same content extent drives the `regionLayout` capability**, not just the
   `Level.Size` metadata (see the **Consistency invariant** below). The per-level
   `StitchedSize(level)` returned to the region/`StitchedTile`/`ScaledStrips`
@@ -196,7 +203,8 @@ registration-relevant magnitude.
 
 - **BIF DP (fixture-gated, Ventana-1):** assert per-level `Size` equals the
   bio-formats `sizeX` chain (`23432,11716,5858,…`) and heights
-  (`21504,10752,…`); `Downsample[i] == 2^i` (exact); L0 unchanged.
+  (`21504,10752,…`); `Downsample[i] == Size0/Size_i` (self-consistent) and
+  within `0.1%` of `2^i` (the #78 ~2× invariant; not forced exact); L0 unchanged.
 - **BIF legacy regression (fixture-gated, OS-1):** assert per-level `Size` is
   **unchanged** from current (raw grid) — proves legacy is untouched (deferred to
   #80).

--- a/formats/bif/bif.go
+++ b/formats/bif/bif.go
@@ -82,14 +82,27 @@ func openFromTIFFFile(file *tiff.File, cfg *format.Config) (format.Reader, error
 	valueLevels := make([]opentile.Level, 0, len(levelIFDs))
 	var levelZeroDepth int
 	var l0Width int
+	var l0Hull opentile.Size
+	gen := classifyGeneration(iscan)
 	for i, c := range levelIFDs {
-		l, err := newLevelImpl(i, c, iscan.ScanRes, scanWhite, classifyGeneration(iscan), encodeInfo, file.ReaderAt())
+		l, err := newLevelImpl(i, c, iscan.ScanRes, scanWhite, gen, encodeInfo, file.ReaderAt())
 		if err != nil {
 			return nil, err
 		}
 		if i == 0 {
 			levelZeroDepth = l.imageDepth
 			l0Width = l.size.W
+			l0Hull = l.size
+		} else if gen == GenerationSpecCompliant {
+			// #78: DP (spec-compliant / DP 200) reduced levels derive their
+			// content extent from the L0 stitched hull by floor-halving, not the
+			// padded IFD ImageWidth (which keeps the un-compacted frame-grid
+			// width). This drives Level.Size, Downsample, AND StitchedSize (all
+			// read l.size), so the pyramid's inter-level scale is exactly 2× and
+			// the compositor clips display tiles to true content. Legacy iScan is
+			// deliberately untouched — its reduced levels still carry frame
+			// overlap (GH #80) and need per-level stitching, not a Size change.
+			l.size = floorHalveSize(l0Hull, i)
 		}
 		levelImpls = append(levelImpls, l)
 		valueLevels = append(valueLevels, opentile.Level{
@@ -156,7 +169,7 @@ func openFromTIFFFile(file *tiff.File, cfg *format.Config) (format.Reader, error
 		file:          file,
 		cfg:           nil, // format.Config not stored; cfg param reserved for future knobs
 		iscan:         iscan,
-		gen:           classifyGeneration(iscan),
+		gen:           gen,
 		encodeInfo:    encodeInfo,
 		levelIFDs:     levelIFDs,
 		associatedIFD: associatedIFDs,

--- a/formats/bif/bif_region_layout_test.go
+++ b/formats/bif/bif_region_layout_test.go
@@ -8,7 +8,8 @@ import (
 
 func TestTilerImplementsRegionLayout(t *testing.T) {
 	tl := &Tiler{levelImpls: []*levelImpl{{
-		index: 0, grid: opentile.Size{W: 2, H: 1}, tileSize: opentile.Size{W: 100, H: 100},
+		index: 0, size: opentile.Size{W: 200, H: 100},
+		grid: opentile.Size{W: 2, H: 1}, tileSize: opentile.Size{W: 100, H: 100},
 		layout: buildNaiveLayout(StitchInput{Cols: 2, Rows: 1, TileW: 100, TileH: 100}),
 	}}}
 	x, y, ok := tl.TileOrigin(0, 1, 0)

--- a/formats/bif/geometry_test.go
+++ b/formats/bif/geometry_test.go
@@ -1,0 +1,20 @@
+package bif
+
+import (
+	"testing"
+
+	opentile "github.com/wsilabs/opentile-go"
+)
+
+func TestFloorHalveSize(t *testing.T) {
+	// Ventana-1 DP hull → bio-formats sizeX/sizeY chain.
+	hull := opentile.Size{W: 23432, H: 21504}
+	wantW := []int{23432, 11716, 5858, 2929, 1464, 732, 366, 183}
+	wantH := []int{21504, 10752, 5376, 2688, 1344, 672, 336, 168}
+	for i := range wantW {
+		got := floorHalveSize(hull, i)
+		if got.W != wantW[i] || got.H != wantH[i] {
+			t.Errorf("floorHalveSize(hull,%d) = %dx%d, want %dx%d", i, got.W, got.H, wantW[i], wantH[i])
+		}
+	}
+}

--- a/formats/bif/level.go
+++ b/formats/bif/level.go
@@ -268,6 +268,18 @@ func newLevelImpl(
 // Both local fixtures record OverlapX = OverlapY = 0, so this fold
 // returns {0, 0} on real data and the non-zero path is exercised
 // only by synthetic-XMP unit tests.
+// floorHalveSize halves sz by 2, n times, with integer (floor) division —
+// reproducing bio-formats' per-resolution sizeX/sizeY chain for DP pyramids
+// (e.g. 23432 → 11716 → 5858 → 2929 → 1464 → …). n == 0 returns sz.
+func floorHalveSize(sz opentile.Size, n int) opentile.Size {
+	w, h := sz.W, sz.H
+	for k := 0; k < n; k++ {
+		w /= 2
+		h /= 2
+	}
+	return opentile.Size{W: w, H: h}
+}
+
 func weightedAverageOverlap(ei *bifxml.EncodeInfo) opentile.Point {
 	var sumX, sumY, count int
 	for _, info := range ei.ImageInfos {
@@ -301,12 +313,12 @@ func (l *levelImpl) TileOrigin(col, row int) (x, y int, ok bool) {
 	return l.layout.TileOrigin(col, row)
 }
 
-// StitchedSize returns this level's stitched dimensions (== Size()).
+// StitchedSize returns this level's stitched content extent (== Size()). It is
+// the single source of truth for the compositor's clip bounds; for DP reduced
+// levels this is the hull-derived content extent (#78). The stored-grid extent
+// (cols*tileW from the naive layout) is recoverable as Grid*TileSize.
 func (l *levelImpl) StitchedSize() (w, h int, ok bool) {
-	if l.layout == nil {
-		return l.size.W, l.size.H, true
-	}
-	return l.layout.Width, l.layout.Height, true
+	return l.size.W, l.size.H, true
 }
 
 // TilesIntersecting returns the image-grid tiles whose stitched extent touches

--- a/formats/bif/level_test.go
+++ b/formats/bif/level_test.go
@@ -255,9 +255,12 @@ func TestLevelTileReader(t *testing.T) {
 func TestLevelImplLayoutAccessors(t *testing.T) {
 	// Construct a minimal levelImpl with an injected layout to exercise the
 	// accessor wiring (the real layout is built in newLevelImpl).
+	// size must be set explicitly: StitchedSize() now returns l.size (the
+	// hull-derived content extent, #78) rather than layout.Width/Height.
 	l := &levelImpl{
 		index: 0, grid: opentile.Size{W: 2, H: 1},
 		tileSize: opentile.Size{W: 1024, H: 1024},
+		size:     opentile.Size{W: 2048, H: 1024},
 		layout:   buildNaiveLayout(StitchInput{Cols: 2, Rows: 1, TileW: 1024, TileH: 1024}),
 	}
 	x, y, ok := l.TileOrigin(1, 0)

--- a/formats/ife/cervix_test.go
+++ b/formats/ife/cervix_test.go
@@ -63,17 +63,19 @@ func TestCervixEndToEnd(t *testing.T) {
 		t.Errorf("level count = %d, want 9", len(levels))
 	}
 
-	// Native (L0) and coarsest (L8) dims per T3 gate.
+	// Native (L0) and coarsest (L8) dims per T3 gate; L2-L8 updated to
+	// true content extent (scale-derived from TILE_TABLE x_extent/y_extent,
+	// fixing the old overlap-padded values — every adjacent ratio is now ~2×).
 	wantSizes := []opentile.Size{
 		{W: 126976, H: 88576},
 		{W: 63488, H: 44288},
-		{W: 31744, H: 22272},
-		{W: 15872, H: 11264},
-		{W: 7936, H: 5632},
-		{W: 4096, H: 2816},
-		{W: 2048, H: 1536},
-		{W: 1024, H: 768},
-		{W: 512, H: 512},
+		{W: 31744, H: 22144},
+		{W: 15872, H: 11072},
+		{W: 7936, H: 5536},
+		{W: 3968, H: 2768},
+		{W: 1984, H: 1384},
+		{W: 992, H: 692},
+		{W: 496, H: 346},
 	}
 	for i, want := range wantSizes {
 		if got := levels[i].Size; got != want {

--- a/formats/ife/geometry.go
+++ b/formats/ife/geometry.go
@@ -1,0 +1,53 @@
+package ife
+
+import (
+	"math"
+
+	opentile "github.com/wsilabs/opentile-go"
+)
+
+// ifeGeometry computes per-API-level content Size and Downsample from the layer
+// scales and the L0 content extent. api is native-first (api[0] = finest =
+// max scale). The spec's downsample is max_scale/scale; the content extent at
+// each level is L0_content / downsample, rounded. L0 content comes from
+// TileTable.x_extent/y_extent when those are valid pixel dimensions, else the
+// padded XTiles*256 grid (the cervix fixture stores tile counts there).
+func ifeGeometry(api []LayerExtent, tt TileTable) (sizes []opentile.Size, downs []float64) {
+	n := len(api)
+	sizes = make([]opentile.Size, n)
+	downs = make([]float64, n)
+	if n == 0 {
+		return sizes, downs
+	}
+	maxScale := float64(api[0].Scale)
+
+	size0 := opentile.Size{
+		W: int(api[0].XTiles) * TileSidePixels,
+		H: int(api[0].YTiles) * TileSidePixels,
+	}
+	if validPixelExtent(int(tt.XExtent), int(api[0].XTiles)) &&
+		validPixelExtent(int(tt.YExtent), int(api[0].YTiles)) {
+		size0 = opentile.Size{W: int(tt.XExtent), H: int(tt.YExtent)}
+	}
+
+	for i := range api {
+		ds := maxScale / float64(api[i].Scale)
+		downs[i] = ds
+		sizes[i] = opentile.Size{
+			W: int(math.Round(float64(size0.W) / ds)),
+			H: int(math.Round(float64(size0.H) / ds)),
+		}
+	}
+	return sizes, downs
+}
+
+// validPixelExtent reports whether ext is a plausible pixel dimension for a
+// tile grid of `tiles` columns/rows: it must lie in ((tiles-1)*256, tiles*256].
+// Tile COUNTS (e.g. cervix's x_extent) fail this test, so the caller falls back
+// to the padded grid base.
+func validPixelExtent(ext, tiles int) bool {
+	if tiles <= 0 {
+		return false
+	}
+	return ext > (tiles-1)*TileSidePixels && ext <= tiles*TileSidePixels
+}

--- a/formats/ife/geometry_test.go
+++ b/formats/ife/geometry_test.go
@@ -1,0 +1,64 @@
+package ife
+
+import (
+	"testing"
+
+	opentile "github.com/wsilabs/opentile-go"
+)
+
+func TestIFEGeometryScaleRatios(t *testing.T) {
+	// 3 layers, native-first: scales 4,2,1 → downsamples 1,2,4.
+	api := []LayerExtent{
+		{XTiles: 8, YTiles: 6, Scale: 4},
+		{XTiles: 4, YTiles: 3, Scale: 2},
+		{XTiles: 2, YTiles: 2, Scale: 1},
+	}
+	// x_extent valid pixels (not a multiple of 256): in ((8-1)*256, 8*256] = (1792,2048].
+	tt := TileTable{XExtent: 1900, YExtent: 1400}
+	sizes, downs := ifeGeometry(api, tt)
+	if sizes[0] != (opentile.Size{W: 1900, H: 1400}) {
+		t.Fatalf("L0 size = %v, want 1900x1400 (x_extent anchor)", sizes[0])
+	}
+	wantDown := []float64{1, 2, 4}
+	for i := range downs {
+		if downs[i] != wantDown[i] {
+			t.Errorf("L%d downsample = %v, want %v", i, downs[i], wantDown[i])
+		}
+	}
+	// Exact 2x ratios (round of 1900/2=950, /4=475).
+	if sizes[1] != (opentile.Size{W: 950, H: 700}) || sizes[2] != (opentile.Size{W: 475, H: 350}) {
+		t.Fatalf("scaled sizes = %v %v, want 950x700 475x350", sizes[1], sizes[2])
+	}
+}
+
+func TestIFEGeometryInvalidExtentFallsBack(t *testing.T) {
+	api := []LayerExtent{
+		{XTiles: 8, YTiles: 6, Scale: 2},
+		{XTiles: 4, YTiles: 3, Scale: 1},
+	}
+	// x_extent carries TILE COUNTS (cervix non-conformance): 8 is not in (1792,2048].
+	tt := TileTable{XExtent: 8, YExtent: 6}
+	sizes, downs := ifeGeometry(api, tt)
+	// Falls back to padded L0 (8*256 x 6*256); ratios still exact.
+	if sizes[0] != (opentile.Size{W: 2048, H: 1536}) {
+		t.Fatalf("L0 size = %v, want padded 2048x1536 fallback", sizes[0])
+	}
+	if downs[1] != 2 || sizes[1] != (opentile.Size{W: 1024, H: 768}) {
+		t.Fatalf("L1 down=%v size=%v, want 2 / 1024x768", downs[1], sizes[1])
+	}
+}
+
+func TestValidPixelExtent(t *testing.T) {
+	if !validPixelExtent(1900, 8) { // (1792,2048]
+		t.Error("1900 with 8 tiles should be valid pixels")
+	}
+	if validPixelExtent(8, 8) { // tile-count, not pixels
+		t.Error("8 with 8 tiles should be invalid (tile count)")
+	}
+	if !validPixelExtent(2048, 8) { // exact multiple is valid
+		t.Error("2048 with 8 tiles should be valid")
+	}
+	if validPixelExtent(1792, 8) { // == (tiles-1)*256, boundary excluded
+		t.Error("1792 with 8 tiles should be invalid")
+	}
+}

--- a/formats/ife/tiler.go
+++ b/formats/ife/tiler.go
@@ -64,10 +64,7 @@ func openIFE(r io.ReaderAt, size int64, _ *format.Config) (format.Reader, error)
 
 	levelImpls := make([]*levelImpl, len(apiOrder))
 	valueLevels := make([]opentile.Level, len(apiOrder))
-	// L0 width comes from apiOrder[0] (finest resolution = first in API order),
-	// which maps to fileOrder[len-1] (last entry in coarsest-first storage).
-	l0FileIdx := len(apiOrder) - 1
-	l0Width := int(fileOrder[l0FileIdx].XTiles) * TileSidePixels
+	sizes, downs := ifeGeometry(apiOrder, tt)
 	for i := range apiOrder {
 		// Compute TileMaxSize for this level: walk the per-level
 		// slice of TILE_OFFSETS entries and find the maximum byte
@@ -83,17 +80,16 @@ func openIFE(r io.ReaderAt, size int64, _ *format.Config) (format.Reader, error)
 				maxSize = s
 			}
 		}
-		levelW := int(ext.XTiles) * TileSidePixels
 		impl := &levelImpl{apiIndex: i, maxTileSize: int(maxSize)}
 		levelImpls[i] = impl
 		valueLevels[i] = opentile.Level{
 			Index:        i,
 			PyramidIndex: i,
-			Size:         opentile.Size{W: levelW, H: int(ext.YTiles) * TileSidePixels},
+			Size:         sizes[i],
 			TileSize:     opentile.Size{W: TileSidePixels, H: TileSidePixels},
 			Grid:         opentile.Size{W: int(ext.XTiles), H: int(ext.YTiles)},
 			Compression:  compression,
-			Downsample:   float64(l0Width) / float64(levelW),
+			Downsample:   downs[i],
 		}
 	}
 	images := []opentile.Pyramid{{Name: "", Index: 0, Levels: valueLevels}}

--- a/pyramid_content_extent_test.go
+++ b/pyramid_content_extent_test.go
@@ -96,6 +96,24 @@ func TestBIFVentanaStitchedTileClipsOverscan(t *testing.T) {
 	}
 }
 
+func TestIFECervixRatiosConsistent(t *testing.T) {
+	s := openFixture(t, "ife", "cervix_2x_jpeg.iris")
+	defer s.Close()
+	levels := s.Levels()
+	for i := 1; i < len(levels); i++ {
+		rw := float64(levels[i-1].Size.W) / float64(levels[i].Size.W)
+		rh := float64(levels[i-1].Size.H) / float64(levels[i].Size.H)
+		// Drift is gone: every adjacent ratio is ~2 (the bug had 1.5–1.99 at
+		// coarse levels). Tolerate <=1px rounding => ratio within [1.95, 2.05].
+		if rw < 1.95 || rw > 2.05 || rh < 1.95 || rh > 2.05 {
+			t.Errorf("L%d->L%d ratio = %.4f/%.4f, want ~2.0", i-1, i, rw, rh)
+		}
+		if d := levels[i].Downsample / levels[i-1].Downsample; d < 1.95 || d > 2.05 {
+			t.Errorf("L%d/L%d Downsample ratio = %.4f, want ~2.0", i, i-1, d)
+		}
+	}
+}
+
 func TestBIFLegacySizeUnchanged(t *testing.T) {
 	s := openFixture(t, "bif", "OS-1.bif")
 	defer s.Close()

--- a/pyramid_content_extent_test.go
+++ b/pyramid_content_extent_test.go
@@ -1,0 +1,112 @@
+package opentile_test
+
+import (
+	"errors"
+	"math"
+	"os"
+	"path/filepath"
+	"testing"
+
+	opentile "github.com/wsilabs/opentile-go"
+	"github.com/wsilabs/opentile-go/decoder"
+	_ "github.com/wsilabs/opentile-go/decoder/all"
+	_ "github.com/wsilabs/opentile-go/formats/all"
+)
+
+// openFixture opens dir/<sub>/<name> via the public API, skipping when the
+// fixture corpus or the file is absent.
+func openFixture(t *testing.T, sub, name string) *opentile.Slide {
+	t.Helper()
+	dir := os.Getenv("OPENTILE_TESTDIR")
+	if dir == "" {
+		t.Skip("OPENTILE_TESTDIR not set")
+	}
+	p := filepath.Join(dir, sub, name)
+	if _, err := os.Stat(p); err != nil {
+		t.Skipf("fixture missing: %v", err)
+	}
+	s, err := opentile.OpenFile(p)
+	if err != nil {
+		t.Fatalf("open %s: %v", name, err)
+	}
+	return s
+}
+
+func ceilDivT(a, b int) int { return (a + b - 1) / b }
+
+func TestBIFVentanaContentExtent(t *testing.T) {
+	s := openFixture(t, "bif", "Ventana-1.bif")
+	defer s.Close()
+	wantW := []int{23432, 11716, 5858, 2929, 1464, 732, 366, 183}
+	wantH := []int{21504, 10752, 5376, 2688, 1344, 672, 336, 168}
+	levels := s.Levels()
+	if len(levels) != len(wantW) {
+		t.Fatalf("level count %d, want %d", len(levels), len(wantW))
+	}
+	for i, l := range levels {
+		if l.Size.W != wantW[i] || l.Size.H != wantH[i] {
+			t.Errorf("L%d Size = %dx%d, want %dx%d", i, l.Size.W, l.Size.H, wantW[i], wantH[i])
+		}
+		// Downsample is the literal L0/level width ratio (self-consistent with
+		// Size, the openslide convention) AND within rounding of 2^i — the #78
+		// goal. The bug had L1 at 1.907; now L1–L3 are exactly 2/4/8 and floor-
+		// halved L4+ drift <0.05% (e.g. 23432/1464 = 16.005), not a forced 2^i.
+		wantSelf := float64(levels[0].Size.W) / float64(l.Size.W)
+		if l.Downsample != wantSelf {
+			t.Errorf("L%d Downsample = %v, want self-consistent %v (== Size0/Size_i)", i, l.Downsample, wantSelf)
+		}
+		pow := math.Pow(2, float64(i))
+		if math.Abs(l.Downsample/pow-1) > 0.001 {
+			t.Errorf("L%d Downsample = %v drifts >0.1%% from 2^%d=%v (#78: pyramid must be ~2x)", i, l.Downsample, i, pow)
+		}
+		g := l.StitchedGrid()
+		if g.W != ceilDivT(l.Size.W, l.TileSize.W) || g.H != ceilDivT(l.Size.H, l.TileSize.H) {
+			t.Errorf("L%d StitchedGrid %v != ceil(Size %v / Tile %v)", i, g, l.Size, l.TileSize)
+		}
+	}
+}
+
+func TestBIFVentanaStitchedTileClipsOverscan(t *testing.T) {
+	s := openFixture(t, "bif", "Ventana-1.bif")
+	defer s.Close()
+	l1, err := s.Level(1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	g := l1.StitchedGrid() // W = ceil(11716/1024) = 12
+	img, err := l1.StitchedTile(g.W-1, 0)
+	if errors.Is(err, decoder.ErrCodecUnavailable) {
+		t.Skip("decode unavailable (nocgo)")
+	}
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Last column origin = (g.W-1)*TileW = 11*1024 = 11264; content ends at
+	// Size.W = 11716, so local columns >= 11716-11264 = 452 are overscan → white.
+	contentCols := l1.Size.W - (g.W-1)*l1.TileSize.W
+	bpp := 3
+	for _, y := range []int{0, img.Height / 2, img.Height - 1} {
+		for _, x := range []int{contentCols + 8, img.Width - 1} {
+			o := y*img.Stride + x*bpp
+			if img.Pix[o] != 0xFF || img.Pix[o+1] != 0xFF || img.Pix[o+2] != 0xFF {
+				t.Fatalf("overscan pixel (%d,%d) = %d,%d,%d, want white 255 (StitchedSize must == Size)",
+					x, y, img.Pix[o], img.Pix[o+1], img.Pix[o+2])
+			}
+		}
+	}
+}
+
+func TestBIFLegacySizeUnchanged(t *testing.T) {
+	s := openFixture(t, "bif", "OS-1.bif")
+	defer s.Close()
+	// Legacy iScan is deferred to #80 — its reduced-level Size must stay the raw
+	// (un-compacted) grid extent. Pin L0/L1 so this change can't silently alter
+	// legacy. (105818 hull at L0; 59392 = 58*1024 raw grid at L1.)
+	levels := s.Levels()
+	if levels[0].Size.W != 105818 {
+		t.Errorf("OS-1 L0 Size.W = %d, want 105818 (unchanged hull)", levels[0].Size.W)
+	}
+	if levels[1].Size.W != 59392 {
+		t.Errorf("OS-1 L1 Size.W = %d, want 59392 (raw grid, legacy untouched — see #80)", levels[1].Size.W)
+	}
+}

--- a/tests/fixtures/Ventana-1.bif.json
+++ b/tests/fixtures/Ventana-1.bif.json
@@ -23,7 +23,7 @@
     {
       "index": 1,
       "size": [
-        12288,
+        11716,
         10752
       ],
       "tile_size": [
@@ -41,7 +41,7 @@
     {
       "index": 2,
       "size": [
-        6144,
+        5858,
         5376
       ],
       "tile_size": [
@@ -59,7 +59,7 @@
     {
       "index": 3,
       "size": [
-        3072,
+        2929,
         2688
       ],
       "tile_size": [
@@ -77,7 +77,7 @@
     {
       "index": 4,
       "size": [
-        1536,
+        1464,
         1344
       ],
       "tile_size": [
@@ -95,7 +95,7 @@
     {
       "index": 5,
       "size": [
-        768,
+        732,
         672
       ],
       "tile_size": [
@@ -113,7 +113,7 @@
     {
       "index": 6,
       "size": [
-        384,
+        366,
         336
       ],
       "tile_size": [
@@ -131,7 +131,7 @@
     {
       "index": 7,
       "size": [
-        192,
+        183,
         168
       ],
       "tile_size": [
@@ -210,6 +210,10 @@
       "sha256": "43ec236da00003082f44e045de1a2a2fd5bc1cc53ffbf3596287c114f4bb932a",
       "reason": "bottom-right corner; OOB fill in both axes"
     },
+    "1:11:5": {
+      "sha256": "83a1296652384546235d98e272b32277091fe7b8716653ff47f0639294144dbe",
+      "reason": "right-edge mid-column; OOB fill in x via 'right of image' callback"
+    },
     "1:1:5": {
       "sha256": "075ea187dad3e8514333be988200b163049b09aa2a051086854bdfed2d0b7037",
       "reason": "near-left mid-row"
@@ -270,6 +274,10 @@
       "sha256": "3ef45188915873ca6bd21b75b43ea1bab26911ac9da1699459e9e3442183cc4a",
       "reason": "top-right corner; OOB fill in x"
     },
+    "2:5:3": {
+      "sha256": "c54de8b35164797dab5c5f4231452e66fc4c4feaeba80f752283b20360746a5b",
+      "reason": "right-edge mid-column; OOB fill in x via 'right of image' callback"
+    },
     "2:5:5": {
       "sha256": "70f5ec9f89b0b19d3ccd19489c08b08cfa275aa5b8cb51beed64427eda60f01a",
       "reason": "bottom-right corner; OOB fill in both axes"
@@ -293,6 +301,10 @@
     "3:2:0": {
       "sha256": "824d6450889c914173fe1247d90f29397efd509ad82fa4eb6fa3e88ec7346249",
       "reason": "top-right corner; OOB fill in x"
+    },
+    "3:2:1": {
+      "sha256": "e7cd157e8732f13dddbf1bbaf87fb1c3cacf59d51ade38767a1386796c7c776d",
+      "reason": "right-edge mid-column; OOB fill in x via 'right of image' callback"
     },
     "3:2:2": {
       "sha256": "2ff552f9063db17867d2d06e3e92032f7617e05bf04c60844e7aa8bfd253489b",

--- a/tests/fixtures/cervix_2x_jpeg.ife.json
+++ b/tests/fixtures/cervix_2x_jpeg.ife.json
@@ -42,7 +42,7 @@
       "index": 2,
       "size": [
         31744,
-        22272
+        22144
       ],
       "tile_size": [
         256,
@@ -60,7 +60,7 @@
       "index": 3,
       "size": [
         15872,
-        11264
+        11072
       ],
       "tile_size": [
         256,
@@ -78,7 +78,7 @@
       "index": 4,
       "size": [
         7936,
-        5632
+        5536
       ],
       "tile_size": [
         256,
@@ -95,8 +95,8 @@
     {
       "index": 5,
       "size": [
-        4096,
-        2816
+        3968,
+        2768
       ],
       "tile_size": [
         256,
@@ -113,8 +113,8 @@
     {
       "index": 6,
       "size": [
-        2048,
-        1536
+        1984,
+        1384
       ],
       "tile_size": [
         256,
@@ -131,8 +131,8 @@
     {
       "index": 7,
       "size": [
-        1024,
-        768
+        992,
+        692
       ],
       "tile_size": [
         256,
@@ -149,8 +149,8 @@
     {
       "index": 8,
       "size": [
-        512,
-        512
+        496,
+        346
       ],
       "tile_size": [
         256,
@@ -273,6 +273,10 @@
       "sha256": "4b223996383742f7ab303a8d505e75e359113574d7ba17a4270cc3e83db88997",
       "reason": "interior diagonal q2 (center)"
     },
+    "2:62:86": {
+      "sha256": "a682a6088640a2c319b656921f042f5813557ad09e23cbc2d95eb5c0ef43bde0",
+      "reason": "bottom-edge mid-row; OOB fill in y via 'below image' callback"
+    },
     "2:93:65": {
       "sha256": "f709b3abb12874e56e439ea1ee91be4a50e716486d630de40b52c93d7e8f6fd6",
       "reason": "interior diagonal q3"
@@ -301,6 +305,10 @@
       "sha256": "16403511baa567b645a85f96a13ff63fddccd57402bbc26a61604afc6bffd5c7",
       "reason": "interior diagonal q2 (center)"
     },
+    "3:31:43": {
+      "sha256": "896e06ba2c0d12320f15ae33d8cbc8c9ae2601c6370b58ca343d7c9c2d306555",
+      "reason": "bottom-edge mid-row; OOB fill in y via 'below image' callback"
+    },
     "3:46:33": {
       "sha256": "d2a1f2ffb0609ffcd8860b26a2b55928bb444506e633f07581468568fa26970d",
       "reason": "interior diagonal q3"
@@ -328,6 +336,10 @@
     "4:15:11": {
       "sha256": "4e67756c6464018182818aea72bb7542a7b6dc8cb81756fa9b60b15ee2e69416",
       "reason": "interior diagonal q2 (center)"
+    },
+    "4:15:21": {
+      "sha256": "0bfb6ddf5523f725fb854d35226b4db26260f8281a59ef2e7430a5129bbda1e5",
+      "reason": "bottom-edge mid-row; OOB fill in y via 'below image' callback"
     },
     "4:1:11": {
       "sha256": "af6bea856fa13d013ed02e923c115aed9852a61d87846c855c241e5759f8e4f0",
@@ -365,6 +377,10 @@
       "sha256": "904c4e27bb32ddbca82b6e944c752bbe189ee04ca91f56d31eab38ba2329172a",
       "reason": "top-right corner; OOB fill in x"
     },
+    "5:15:5": {
+      "sha256": "a819c6292c1aff9a49b654fbffcf6e021cd00ebd044b3c1fa359dd29b9905370",
+      "reason": "right-edge mid-column; OOB fill in x via 'right of image' callback"
+    },
     "5:15:10": {
       "sha256": "a432cba97da90b02b039eedc3f36b391054e217d73e3b3bc3c61c5aa04d458d7",
       "reason": "bottom-right corner; OOB fill in both axes"
@@ -384,6 +400,10 @@
     "5:8:5": {
       "sha256": "8c32a1d85f4fe6774c806c20a0cd8ad3a93e6128c5d60708fd9a312a9789d9e7",
       "reason": "interior diagonal q2 (center)"
+    },
+    "5:8:10": {
+      "sha256": "2239338891e37bb887be4d2ddc62c4a9daa07ec322bc6d6e11cf4cb8082fcc71",
+      "reason": "bottom-edge mid-row; OOB fill in y via 'below image' callback"
     },
     "6:0:0": {
       "sha256": "1559ac6d8210f964780c31746d5ebe1b21146f6824251dd439798cc79c1c0dde",
@@ -409,6 +429,10 @@
       "sha256": "75c254e04358ffda2edf8a1822fb313ec92912daba68d7cf98b601c98ed61b95",
       "reason": "interior diagonal q2 (center)"
     },
+    "6:4:5": {
+      "sha256": "4abf085a4cacc1fde3ed788fa8a59ea9050fe7b6e4f0068754601a30a2d81f4a",
+      "reason": "bottom-edge mid-row; OOB fill in y via 'below image' callback"
+    },
     "6:6:4": {
       "sha256": "544ceabd66867a80bb2ebadde46aa8ab7cb300acafd31d9e66d201d7abd7859c",
       "reason": "interior diagonal q3"
@@ -416,6 +440,10 @@
     "6:7:0": {
       "sha256": "b19d0a0448d78b46bccf4f080cdceb2ea1a3b5077d83f319a5f6a910276a67bb",
       "reason": "top-right corner; OOB fill in x"
+    },
+    "6:7:3": {
+      "sha256": "f337883cd58383b0fe8fc8f3631d9343f9f94189d5a5350646d1580912113392",
+      "reason": "right-edge mid-column; OOB fill in x via 'right of image' callback"
     },
     "6:7:5": {
       "sha256": "72c1ad7d39158094510462788a8fbb18cab16206df4692a61fcd7a8962154df1",
@@ -441,9 +469,17 @@
       "sha256": "71c4b16e75223fa6ece24b2dd813dc5a0f2857a20157fb27d6db502de4822098",
       "reason": "interior diagonal q2 (center)"
     },
+    "7:2:2": {
+      "sha256": "cc0df17daa7c5ccf1b1145b7773179e8e2fc5f27381f27a589a0639d5a094ac7",
+      "reason": "bottom-edge mid-row; OOB fill in y via 'below image' callback"
+    },
     "7:3:0": {
       "sha256": "12f4a969cefa29b0110db4a53b6e3412819fb7d27940f98eace3dee3ce6e0e16",
       "reason": "top-right corner; OOB fill in x"
+    },
+    "7:3:1": {
+      "sha256": "0ae3fc7dd4cc61e14f77a23b81f1e418bade5d8d07b3324392fcf43270513841",
+      "reason": "right-edge mid-column; OOB fill in x via 'right of image' callback"
     },
     "7:3:2": {
       "sha256": "18e3839c0c3f72b4d321a0967cb5543e10bc4eda1d543197135a1fdeb9271eec",

--- a/tests/parity/bif_geometry_test.go
+++ b/tests/parity/bif_geometry_test.go
@@ -53,13 +53,16 @@ var bifFixtures = []bifFixture{
 			// extent (24576) — the 24th column is phantom padding. Grid stays 24×21
 			// (raw frame addressing unchanged). See GH #60 / stitch.go.
 			{W: 23432, H: 21504, TileW: 1024, TileH: 1024, GridW: 24, GridH: 21, OverlapX: 2, OverlapY: 0},
-			{W: 12288, H: 10752, TileW: 1024, TileH: 1024, GridW: 12, GridH: 11},
-			{W: 6144, H: 5376, TileW: 1024, TileH: 1024, GridW: 6, GridH: 6},
-			{W: 3072, H: 2688, TileW: 1024, TileH: 1024, GridW: 3, GridH: 3},
-			{W: 1536, H: 1344, TileW: 1024, TileH: 1024, GridW: 2, GridH: 2},
-			{W: 768, H: 672, TileW: 1024, TileH: 1024, GridW: 1, GridH: 1},
-			{W: 384, H: 336, TileW: 1024, TileH: 1024, GridW: 1, GridH: 1},
-			{W: 192, H: 168, TileW: 1024, TileH: 1024, GridW: 1, GridH: 1},
+			// L1-L7 derive from the L0 stitched hull via floor-halving (#78):
+			// Size = floor(L0_size / 2^i), matching bio-formats behaviour.
+			// Grid stays at the raw frame count (12, 6, 3, 2, 1, 1, 1).
+			{W: 11716, H: 10752, TileW: 1024, TileH: 1024, GridW: 12, GridH: 11},
+			{W: 5858, H: 5376, TileW: 1024, TileH: 1024, GridW: 6, GridH: 6},
+			{W: 2929, H: 2688, TileW: 1024, TileH: 1024, GridW: 3, GridH: 3},
+			{W: 1464, H: 1344, TileW: 1024, TileH: 1024, GridW: 2, GridH: 2},
+			{W: 732, H: 672, TileW: 1024, TileH: 1024, GridW: 1, GridH: 1},
+			{W: 366, H: 336, TileW: 1024, TileH: 1024, GridW: 1, GridH: 1},
+			{W: 183, H: 168, TileW: 1024, TileH: 1024, GridW: 1, GridH: 1},
 		},
 		scanRes:        0.25,
 		generation:     "spec-compliant",

--- a/tests/parity/ife_geometry_test.go
+++ b/tests/parity/ife_geometry_test.go
@@ -33,15 +33,20 @@ var ifeFixtures = []ifeFixture{
 		filename: "cervix_2x_jpeg.iris",
 		format:   opentile.FormatIFE,
 		levels: []ifeLevelExpect{
+			// L0 and L1 are unchanged (derived from TILE_TABLE x_extent/y_extent).
+			// L2-L8 updated to true content extent (#78): scale-derived from the
+			// per-layer scale field, fixing the old overlap-padded values.
+			// Every adjacent ratio is now ~2×. Grid is the stored tile count
+			// (unchanged; Grid×TileSize gives the padded raster extent).
 			{W: 126976, H: 88576, TileW: 256, TileH: 256, GridW: 496, GridH: 346},
 			{W: 63488, H: 44288, TileW: 256, TileH: 256, GridW: 248, GridH: 173},
-			{W: 31744, H: 22272, TileW: 256, TileH: 256, GridW: 124, GridH: 87},
-			{W: 15872, H: 11264, TileW: 256, TileH: 256, GridW: 62, GridH: 44},
-			{W: 7936, H: 5632, TileW: 256, TileH: 256, GridW: 31, GridH: 22},
-			{W: 4096, H: 2816, TileW: 256, TileH: 256, GridW: 16, GridH: 11},
-			{W: 2048, H: 1536, TileW: 256, TileH: 256, GridW: 8, GridH: 6},
-			{W: 1024, H: 768, TileW: 256, TileH: 256, GridW: 4, GridH: 3},
-			{W: 512, H: 512, TileW: 256, TileH: 256, GridW: 2, GridH: 2},
+			{W: 31744, H: 22144, TileW: 256, TileH: 256, GridW: 124, GridH: 87},
+			{W: 15872, H: 11072, TileW: 256, TileH: 256, GridW: 62, GridH: 44},
+			{W: 7936, H: 5536, TileW: 256, TileH: 256, GridW: 31, GridH: 22},
+			{W: 3968, H: 2768, TileW: 256, TileH: 256, GridW: 16, GridH: 11},
+			{W: 1984, H: 1384, TileW: 256, TileH: 256, GridW: 8, GridH: 6},
+			{W: 992, H: 692, TileW: 256, TileH: 256, GridW: 4, GridH: 3},
+			{W: 496, H: 346, TileW: 256, TileH: 256, GridW: 2, GridH: 2},
 		},
 		tileMagic: []byte{0xFF, 0xD8}, // JPEG SOI
 	},


### PR DESCRIPTION
## Summary

Closes #78 for **DP-generation BIF** and **IFE** — the two formats whose `Level.Size`/`Downsample` reported a tile-grid-padded (or overlap-compacted-only-at-L0) extent instead of the true content extent, so the pyramid's inter-level scale wasn't exactly ~2× and a consumer building a pyramid from `Level.Size` mis-registered content across the L0/L1 boundary (BIF) or at coarse levels (IFE).

Both now report **true content extent** at every level; `Grid` (the stored tile grid) is unchanged, **tile bytes are byte-identical**, and the padded raster extent is still recoverable as `Grid × TileSize`.

- **BIF (DP only):** reduced levels derive from the L0 stitched hull by floor-halving (`23432→11716→5858→…`, matching bio-formats `sizeX`). The same content extent drives `Level.Size`, `Downsample`, **and** `regionLayout.StitchedSize` (the consistency invariant — so `StitchedTile` clips display-tile overscan to white, matching openslide/bio-formats). **Legacy iScan BIF is untouched** (its reduced levels carry frame overlap, pixel-confirmed — tracked in #80) and pinned by a regression test.
- **IFE:** `Size`/`Downsample` derive from the per-layer `scale` (spec's `max_scale/scale`), anchored to `TILE_TABLE.x_extent/y_extent` when those are valid pixels (the cervix fixture stores tile-counts there → falls back to the padded base but still gets exact ratios).

`Downsample` is the literal `Size[0]/Size[i]` ratio (self-consistent, the openslide convention — required for `ReadRegionScaled` mapping), within rounding of `2^i` (not forced exact; floor-halved `Size` drifts <0.05% at L4+).

Validated by an oracle probe (bio-formats for DP, openslide for legacy) + a pixel-level overlap check that confirmed legacy L1+ must stay out of scope.

Design: `docs/superpowers/specs/2026-06-24-true-content-extent-pyramid-design.md`
Plan: `docs/superpowers/plans/2026-06-24-true-content-extent-pyramid.md`

## Test Plan

- [x] `floorHalveSize` matches the bio-formats `sizeX/sizeY` chain (unit)
- [x] `ifeGeometry`/`validPixelExtent` — scale ratios, `x_extent` anchor, cervix tile-count fallback (unit, fixture-free)
- [x] **Ventana-1**: per-level `Size` == content chain; `Downsample` self-consistent + ~2× within rounding; `StitchedTile` last column clips overscan→white (proves `StitchedSize == Size`)
- [x] **OS-1 legacy**: `Size` pinned **unchanged** (legacy untouched, #80)
- [x] **cervix** IFE: adjacent ratios ~2× (drift gone)
- [x] `go test ./... -race` green (47 pkgs); nocgo build clean; `go vet ./...` clean
- [x] **No tile-byte SHA changed** (geometry-only; verified 0 SHA removals in parity fixtures); other 10 formats byte-identical

## Consumer note

⚠️ DP-BIF reduced-level and IFE `Level.Size`/`Downsample` values change to the corrected ones. Consumers that built pyramids from the old padded values (e.g. wsitools DZI output dims) will see shifted — now correct — output. openscope is the beneficiary (its zoom registration is fixed for DP-BIF + IFE).

## Follow-ups (filed)

- #80 — legacy iScan BIF reduced-level per-level stitching (its `Size` fix is coupled to that)
- #81 — IFE Magnification/MPP-from-wrong-level (separate metadata bug)

🤖 Generated with [Claude Code](https://claude.com/claude-code)