### PR TITLE
fix(#81): IFE Magnification/MPP report true L0, not a downsampled level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,28 @@ The single source of truth for "what was deferred and why" is
 front-page summary; the deferred file has the full reasoning,
 upstream references, and retirement audit per milestone.
 
-## [0.53.0] — 2026-06-24
+## [0.54.0] — 2026-06-24
 
+IFE Magnification/MPP report the true L0 value, not a downsampled level (#81).
+
+### Fixed
+
+- **IFE `Metadata.Magnification` / `Metadata.MPP` now report the source scanner's
+  true level-0 value** (#81). Some encoders (observed on GT450-sourced `.iris`)
+  stamp a *reduced* level's resolution into the L0 `METADATA` header — e.g. header
+  MPP `16.835` = `2⁶ × 0.262968` (the true GT450 scan), magnification `0.625` =
+  `40/64`. When the passed-through `ATTRIBUTES` carry the authoritative L0 values
+  (`aperio.AppMag` / `aperio.MPP`, or the Aperio `ImageDescription` banner
+  `…|AppMag = 40|MPP = 0.262968|…`), opentile-go now prefers those for the
+  cross-format `Magnification` / `MPP`. Non-Aperio IFE (no such attributes) keeps
+  the header value unchanged. The per-field override is independent (MPP can be
+  corrected while magnification isn't, and vice-versa).
+
+### Added
+
+- **`ife.Metadata.MPPFromHeader`** — the raw `METADATA`-header MPP (before the #81
+  L0 correction), parallel to the existing `MagnificationFromHeader`. Callers that
+  want the header value rather than the Attributes-derived L0 value can read it.
 True-content-extent pyramid for DP-BIF + IFE (#78).
 
 ### Fixed

--- a/formats/ife/cervix_test.go
+++ b/formats/ife/cervix_test.go
@@ -151,8 +151,11 @@ func TestCervixEndToEnd(t *testing.T) {
 
 	// Metadata extraction (since v0.8 metadata closeout).
 	cm := tiler.Metadata()
-	if cm.Magnification == 0 {
-		t.Error("Metadata.Magnification = 0; cervix carries 0.625")
+	// GH #81: cervix's METADATA header stamped a reduced level's magnification
+	// (0.625 = 40/64); the true L0 value comes from aperio.AppMag = 40. The raw
+	// header value stays in MagnificationFromHeader.
+	if cm.Magnification != 40 {
+		t.Errorf("Metadata.Magnification = %v, want 40 (L0, corrected from aperio.AppMag; header was 0.625)", cm.Magnification)
 	}
 	if !strings.HasPrefix(cm.Writer, "iris/") {
 		t.Errorf("Writer (v0.20): got %q, want prefix 'iris/' (IFE writer is the Iris codec; source scanner attribution lives in ImageDescription)", cm.Writer)
@@ -188,7 +191,7 @@ func TestCervixEndToEnd(t *testing.T) {
 		t.Fatal("MetadataOf returned !ok on cervix")
 	}
 	if ifeMD.MPP.IsZero() {
-		t.Error("MPP = zero; cervix header carries 16.835")
+		t.Error("MPP = zero; cervix reports 0.262968 (L0, corrected from aperio.MPP per #81)")
 	}
 	if ifeMD.AttributesFormat != AttributesFormatFreeText {
 		t.Errorf("AttributesFormat = %v, want free-text", ifeMD.AttributesFormat)
@@ -212,18 +215,22 @@ func TestCervixEndToEnd(t *testing.T) {
 
 	// v0.17 cross-format assertions on cervix's real metadata.
 	cm = tiler.Metadata()
-	// MPP: cervix header reports 16.835 µm/px (a 2× downsample of
-	// a 0.263 µm/px GT450 scan). f32→f64 widening introduces a tiny
-	// epsilon (16.835 isn't exact in IEEE-754 binary); assert
-	// directionally rather than against a specific bit pattern.
-	if cm.MPP.X < 16.83 || cm.MPP.X > 16.84 {
-		t.Errorf("cross.MPP.X = %v, want ≈ 16.835", cm.MPP.X)
+	// GH #81: cervix's METADATA header reports 16.835 µm/px — a 2^6 downsample of
+	// the true 0.262968 µm/px GT450 L0 scan (16.835/0.262968 = 64). cross.MPP now
+	// reports the authoritative L0 value from aperio.MPP; the raw header value is
+	// preserved in ifeMD.MPPFromHeader.
+	if cm.MPP.X < 0.2629 || cm.MPP.X > 0.2630 {
+		t.Errorf("cross.MPP.X = %v, want ≈ 0.262968 (L0, corrected from aperio.MPP)", cm.MPP.X)
 	}
 	if cm.MPP.X != cm.MPP.Y {
 		t.Errorf("cross.MPP.X (%v) != Y (%v); IFE pixels are isotropic", cm.MPP.X, cm.MPP.Y)
 	}
 	if cm.MPP.Symmetric() == 0 {
 		t.Error("cross.MPP.Symmetric() = 0; IFE pixels are isotropic, should be non-zero")
+	}
+	// The raw (downsampled) header MPP stays available for transparency.
+	if ifeMD.MPPFromHeader.X < 16.83 || ifeMD.MPPFromHeader.X > 16.84 {
+		t.Errorf("MPPFromHeader.X = %v, want ≈ 16.835 (raw header value)", ifeMD.MPPFromHeader.X)
 	}
 	// Vendor passthrough: every IFE attribute available under "iris.".
 	if got := cm.Properties["iris.aperio.AppMag"]; got != "40" {

--- a/formats/ife/metadata.go
+++ b/formats/ife/metadata.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"io"
 	"math"
+	"strconv"
+	"strings"
 
 	opentile "github.com/wsilabs/opentile-go"
 	"github.com/wsilabs/opentile-go/decoder"
@@ -88,6 +90,13 @@ type Metadata struct {
 	// override can reach it directly.
 	MagnificationFromHeader float32
 
+	// MPPFromHeader is the microns-per-pixel from the METADATA block's f32
+	// field (widened to f64), before any Attributes-derived L0 correction.
+	// Zero when unset. Parallels MagnificationFromHeader: when an encoder
+	// stamped a reduced level's MPP into the header (GH #81), opentile.Metadata.MPP
+	// carries the corrected L0 value and this field carries the raw header value.
+	MPPFromHeader opentile.MPP
+
 	// CodecMajor / CodecMinor / CodecBuild identify the version of
 	// the Iris encoder that wrote this file. Distinct from the
 	// scanner software (which lives in Attributes when the encoder
@@ -158,6 +167,8 @@ func readMetadata(r io.ReaderAt, off uint64, fileSize int64) (Metadata, []openti
 	if mppF32 > 0 {
 		md.MPP = opentile.MPP{X: float64(mppF32), Y: float64(mppF32)}
 	}
+	// Raw header MPP, before any GH #81 Attributes-derived L0 correction below.
+	md.MPPFromHeader = md.MPP
 
 	if attrsOff != NullOffset && attrsOff != 0 {
 		fmtType, ver, kvs, err := readAttributes(r, attrsOff, fileSize)
@@ -182,6 +193,23 @@ func readMetadata(r io.ReaderAt, off uint64, fileSize int64) (Metadata, []openti
 		//     consumers can reach format-specific fields without
 		//     reaching back into md.Attributes.
 		populateIFECrossFields(&md.Metadata, kvs)
+
+		// GH #81: some encoders (observed on GT450-sourced .iris) stamp a
+		// REDUCED level's magnification/MPP into the L0 METADATA header (e.g.
+		// header MPP 16.835 = 2^6 × the true 0.262968 GT450 scan; magnification
+		// 0.625 = 40/64). When the passed-through ATTRIBUTES carry the source
+		// scanner's authoritative L0 values — aperio.AppMag / aperio.MPP, or the
+		// Aperio ImageDescription banner — prefer those for the cross-format
+		// Magnification/MPP. The raw header values stay in MagnificationFromHeader
+		// / MPPFromHeader. Non-Aperio IFE (no such attributes) keeps the header.
+		if appMag, mpp, okMag, okMPP := aperioL0Resolution(kvs, md.ImageDescription); okMag || okMPP {
+			if okMag {
+				md.Magnification = appMag
+			}
+			if okMPP {
+				md.MPP = opentile.MPP{X: mpp, Y: mpp}
+			}
+		}
 	} else {
 		md.AttributesFormat = AttributesFormatUndefined
 	}
@@ -205,6 +233,59 @@ func readMetadata(r io.ReaderAt, off uint64, fileSize int64) (Metadata, []openti
 	}
 
 	return md, assoc, icc, nil
+}
+
+// aperioL0Resolution extracts the source scanner's true level-0 AppMag and MPP
+// from the passed-through ATTRIBUTES, used to correct the IFE METADATA header
+// when an encoder stamped a reduced level's magnification/MPP there (GH #81;
+// observed on GT450-sourced .iris). Prefers the discrete aperio.AppMag /
+// aperio.MPP keys; falls back to the Aperio ImageDescription banner
+// ("…|AppMag = 40|MPP = 0.262968|…"). okMag/okMPP report which were found;
+// returns all-false when no authoritative source is present (non-Aperio IFE).
+func aperioL0Resolution(kvs map[string]string, imageDesc string) (appMag, mpp float64, okMag, okMPP bool) {
+	if f, ok := parsePositiveFloat(kvs["aperio.AppMag"]); ok {
+		appMag, okMag = f, true
+	}
+	if f, ok := parsePositiveFloat(kvs["aperio.MPP"]); ok {
+		mpp, okMPP = f, true
+	}
+	if !okMag {
+		if f, ok := aperioBannerField(imageDesc, "AppMag"); ok {
+			appMag, okMag = f, true
+		}
+	}
+	if !okMPP {
+		if f, ok := aperioBannerField(imageDesc, "MPP"); ok {
+			mpp, okMPP = f, true
+		}
+	}
+	return appMag, mpp, okMag, okMPP
+}
+
+// aperioBannerField extracts "<name> = <float>" from an Aperio ImageDescription
+// banner whose fields are '|'-separated, e.g.
+// aperioBannerField("…|AppMag = 40|MPP = 0.262968", "MPP") → (0.262968, true).
+func aperioBannerField(desc, name string) (float64, bool) {
+	for _, part := range strings.Split(desc, "|") {
+		k, v, found := strings.Cut(part, "=")
+		if !found || strings.TrimSpace(k) != name {
+			continue
+		}
+		if f, ok := parsePositiveFloat(v); ok {
+			return f, true
+		}
+	}
+	return 0, false
+}
+
+// parsePositiveFloat trims and parses s as a float64, returning ok only for a
+// successfully-parsed value > 0.
+func parsePositiveFloat(s string) (float64, bool) {
+	f, err := strconv.ParseFloat(strings.TrimSpace(s), 64)
+	if err != nil || f <= 0 {
+		return 0, false
+	}
+	return f, true
 }
 
 // populateIFECrossFields copies the parsed IFE ATTRIBUTES map onto

--- a/formats/ife/metadata_test.go
+++ b/formats/ife/metadata_test.go
@@ -263,13 +263,19 @@ func TestMetadataBuilderRoundtrip(t *testing.T) {
 
 	// Cross-format Metadata.
 	cm := tiler.Metadata()
-	if cm.Magnification != 20 {
-		t.Errorf("Magnification = %v, want 20", cm.Magnification)
+	// GH #81: this block's header magnification is 20, but it carries an
+	// authoritative aperio.AppMag = 40 attribute → cross.Magnification is the L0
+	// 40, and the raw header 20 is preserved in MagnificationFromHeader.
+	if cm.Magnification != 40 {
+		t.Errorf("Magnification = %v, want 40 (overridden from aperio.AppMag; header was 20)", cm.Magnification)
 	}
-	// v0.17 additions: per-axis MPP populated from header f32 (0.5
-	// is exact in IEEE-754 binary so the f32→f64 widening is exact).
+	if md, ok := MetadataOf(tiler); !ok || md.MagnificationFromHeader != 20 {
+		t.Errorf("MagnificationFromHeader = %v (ok=%v), want raw header 20", md.MagnificationFromHeader, ok)
+	}
+	// MPP: no aperio.MPP and no banner MPP field here, so the header f32 (0.5,
+	// exact in IEEE-754) is kept unchanged (the #81 override is per-field).
 	if cm.MPP.X != 0.5 || cm.MPP.Y != 0.5 {
-		t.Errorf("MPP.X/Y = %v / %v, want 0.5 / 0.5", cm.MPP.X, cm.MPP.Y)
+		t.Errorf("MPP.X/Y = %v / %v, want 0.5 / 0.5 (no aperio.MPP → header kept)", cm.MPP.X, cm.MPP.Y)
 	}
 	if cm.MPP.Symmetric() != 0.5 {
 		t.Errorf("MPP.Symmetric() = %v, want 0.5 (IFE reports symmetric pixels)", cm.MPP.Symmetric())
@@ -531,4 +537,46 @@ func TestCompressionFromImageEncoding(t *testing.T) {
 			t.Errorf("encoding %d = (%v, %v), want (%v, nil)", c.e, got, err, c.want)
 		}
 	}
+}
+
+// GH #81: prefer the source scanner's authoritative L0 AppMag/MPP from
+// ATTRIBUTES over a downsampled-level value in the METADATA header.
+func TestAperioL0Resolution(t *testing.T) {
+	t.Run("discrete aperio keys", func(t *testing.T) {
+		kvs := map[string]string{"aperio.AppMag": "40", "aperio.MPP": "0.262968"}
+		mag, mpp, okMag, okMPP := aperioL0Resolution(kvs, "")
+		if !okMag || mag != 40 {
+			t.Errorf("AppMag = %v (ok=%v), want 40", mag, okMag)
+		}
+		if !okMPP || mpp != 0.262968 {
+			t.Errorf("MPP = %v (ok=%v), want 0.262968", mpp, okMPP)
+		}
+	})
+	t.Run("ImageDescription banner fallback", func(t *testing.T) {
+		desc := "Aperio Leica Biosystems GT450|AppMag = 40|MPP = 0.262968|ScannerType = GT450"
+		mag, mpp, okMag, okMPP := aperioL0Resolution(nil, desc)
+		if !okMag || mag != 40 || !okMPP || mpp != 0.262968 {
+			t.Errorf("banner parse = %v/%v (ok %v/%v), want 40 / 0.262968", mag, mpp, okMag, okMPP)
+		}
+	})
+	t.Run("discrete keys win over banner", func(t *testing.T) {
+		kvs := map[string]string{"aperio.AppMag": "20", "aperio.MPP": "0.5"}
+		mag, mpp, _, _ := aperioL0Resolution(kvs, "AppMag = 40|MPP = 0.25")
+		if mag != 20 || mpp != 0.5 {
+			t.Errorf("= %v/%v, want discrete 20/0.5", mag, mpp)
+		}
+	})
+	t.Run("no authoritative source", func(t *testing.T) {
+		_, _, okMag, okMPP := aperioL0Resolution(map[string]string{"foo": "bar"}, "no fields here")
+		if okMag || okMPP {
+			t.Errorf("want all-false when no AppMag/MPP present, got ok %v/%v", okMag, okMPP)
+		}
+	})
+	t.Run("rejects zero/garbage", func(t *testing.T) {
+		kvs := map[string]string{"aperio.AppMag": "0", "aperio.MPP": "abc"}
+		_, _, okMag, okMPP := aperioL0Resolution(kvs, "")
+		if okMag || okMPP {
+			t.Errorf("want all-false for 0/garbage, got ok %v/%v", okMag, okMPP)
+		}
+	})
 }

--- a/tests/fixtures/cervix_2x_jpeg.ife.json
+++ b/tests/fixtures/cervix_2x_jpeg.ife.json
@@ -166,7 +166,7 @@
     }
   ],
   "metadata": {
-    "magnification": 0.625
+    "magnification": 40
   },
   "sampled_tiles": {
     "0:0:0": {

--- a/tests/parity/cross_format_metadata_test.go
+++ b/tests/parity/cross_format_metadata_test.go
@@ -140,7 +140,7 @@ var cfmExpect = []crossFormatMetadataExpect{
 	},
 	{
 		// IFE cervix: isotropic MPP from IFE-spec MPP attribute.
-		// Magnification (0.625); IFE encoder doesn't write
+		// Magnification: 40 (L0, corrected from aperio.AppMag per #81; header had 0.625). IFE encoder doesn't write
 		// ScannerManufacturer/Model. iris.<key> passthrough (24).
 		fixture:            "cervix_2x_jpeg.iris",
 		subdir:             "ife",


### PR DESCRIPTION
## Summary

Closes #81. Some encoders (observed on GT450-sourced `.iris`) stamp a **reduced level's** resolution into the L0 `METADATA` header — e.g. header MPP `16.835` = `2⁶ × 0.262968` (the true GT450 scan), magnification `0.625` = `40/64`. opentile-go faithfully surfaced those wrong values.

Fix: when the passed-through `ATTRIBUTES` carry the source scanner's **authoritative L0** values, prefer them for the cross-format `Magnification` / `MPP`:
- primary: discrete `aperio.AppMag` / `aperio.MPP` keys;
- fallback: the Aperio `ImageDescription` banner (`…|AppMag = 40|MPP = 0.262968|…`).

Non-Aperio IFE (no such attributes) keeps the header value unchanged. The override is **per-field** (MPP can be corrected while magnification isn't). The raw header values stay available — `MagnificationFromHeader` (existing) and the new **`ife.Metadata.MPPFromHeader`**.

The local **cervix fixture exhibits the exact bug** (40×/0.262968 in `aperio.*`, 0.625/16.835 in the header), so this is verified end-to-end, not just synthetically.

## Test Plan

- [x] `aperioL0Resolution` unit tests (fixture-free): discrete `aperio.*` keys, `ImageDescription` banner fallback, discrete-wins-over-banner, no-source → all-false, zero/garbage rejected
- [x] **cervix**: `Magnification 0.625 → 40`, `MPP 16.835 → 0.262968` (from `aperio.*`), `MPPFromHeader = 16.835` preserved
- [x] Synthetic roundtrip: header mag 20 + `aperio.AppMag=40` → cross `Magnification=40`, `MagnificationFromHeader=20`; MPP `0.5` unchanged (no `aperio.MPP`)
- [x] `TestSlideParity` green (cervix metadata snapshot updated to 40); `tests/parity` green; cog-wsi unaffected
- [x] `go vet ./...`, `go build -tags nocgo ./...` clean

## Related

- #78 (where this surfaced; the pyramid-`Size` issue was separate, shipped in v0.53.0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)