### PR TITLE
fix(ife): read Iris scale-relative resolution convention, not aperio special-case (#81)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,39 @@ The single source of truth for "what was deferred and why" is
 front-page summary; the deferred file has the full reasoning,
 upstream references, and retirement audit per milestone.
 
+## [0.54.1] — 2026-06-24
+
+IFE Magnification/MPP read the Iris scale-relative convention, not a special-cased
+aperio preference (#81 follow-up).
+
+### Fixed
+
+- **IFE `Metadata.Magnification` / `Metadata.MPP` now read the Iris resolution
+  convention as the primary path.** v0.54.0 mis-framed the root cause as "an encoder
+  stamped a downsampled level's value into the header" and preferred `aperio.*` as a
+  special case — which would have surfaced a *wrong* value for any future conformant
+  `.iris` file that lacks aperio attributes. The actual Iris convention (verified by
+  range-probing the canonical 4-layer ×1/×4/×16/×64 `425248_JPEG.iris` reference) is
+  that the `METADATA` header stores **scale-relative** quantities: `magnification` is
+  a coefficient (`physical_mag(layer) = layer.scale × magnification`) and
+  `micronsPerPixel` is the MPP at scale 1 (the coarsest layer). opentile-go now derives
+  the full-resolution values from the finest layer's scale (`max_scale`):
+  `Magnification = magnification × max_scale` and `MPP = micronsPerPixel / max_scale`.
+  The `aperio.AppMag` / `aperio.MPP` (or `ImageDescription` banner) lookup is retained
+  as an **override** for *non-conformant* files — specifically the local
+  `cervix_2x_jpeg.iris` fixture, a re-laddered export (×1…×256) whose header still holds
+  values computed for the original `max_scale = 64` (off by 4× under the convention).
+  Conformant non-Aperio IFE now resolves correctly with no attributes needed. The raw
+  header values remain in `MagnificationFromHeader` / `MPPFromHeader`.
+
+### Documentation
+
+- **`docs/formats/ife.md`** — documents the reversed Iris layer numbering (layer 0 =
+  lowest resolution), the scale-relative header semantics (coefficient + scale-1 MPP),
+  the `× / ÷ max_scale` derivation, and the non-conformant-fixture override. The local
+  `sample_files/ife/ife-format-spec-for-opentile-go.md` byte-layout reference gains a
+  matching METADATA-resolution note.
+
 ## [0.54.0] — 2026-06-24
 
 IFE Magnification/MPP report the true L0 value, not a downsampled level (#81).

--- a/docs/formats/ife.md
+++ b/docs/formats/ife.md
@@ -9,7 +9,7 @@ The IrisDigitalPathology project's bleeding-edge non-TIFF WSI container, designe
 - **Container**: not TIFF. Custom binary layout — fixed-size FILE_HEADER (38 B) at offset 0, chained TILE_TABLE (44 B) → LAYER_EXTENTS (16-B header + 12-B entries) → TILE_OFFSETS (16-B header + 8-B entries). Tile bytes laid out contiguously between the structures and EOF.
 - **Endianness**: little-endian on disk regardless of host.
 - **Detection**: first 4 bytes equal `0x49726973` ("Iris" as LE-uint32). On disk: `0x73 0x69 0x72 0x49`. Implemented via `Factory.SupportsRaw(io.ReaderAt, int64) bool` — runs *before* `tiff.Open` in `opentile.Open`'s dispatch loop, so IFE files never get parsed as TIFF.
-- **Layer ordering**: file stores layers **coarsest-first** (`scales` strictly increasing; first entry is the smallest, last entry is native). opentile-go's API exposes them **native-first** (`Levels()[0]` = highest resolution); the reader inverts the slice at parse time and never re-exposes the file's storage order.
+- **Layer ordering**: file stores layers **coarsest-first** (`scales` strictly increasing; first entry is the smallest, last entry is native). opentile-go's API exposes them **native-first** (`Levels()[0]` = highest resolution); the reader inverts the slice at parse time and never re-exposes the file's storage order. This reversed numbering (Iris "layer 0" = lowest resolution) is why the METADATA header's `magnification` / `micronsPerPixel` are scale-relative rather than absolute — see [Resolution convention](#resolution-convention--header-values-are-scale-relative-v0541-81).
 - **Tile size**: hard-coded at 256×256 pixels per spec (not configurable per-file in v1.0). Image pixel dimensions at layer L: `(x_tiles[L] * 256, y_tiles[L] * 256)`. Right/bottom edge tiles may carry partial content but always full 256×256 framing.
 - **Compression**: per-file (not per-tile). TILE_TABLE.encoding byte selects from JPEG (2), AVIF (3), or the Iris-proprietary codec (1); UNDEFINED (0) and unknown values are rejected at Open time. Tile bytes are **self-contained** — each is a complete JPEG / AVIF / IRIS bytestream. No JPEGTables splice (unlike SVS / BIF).
 - **Sparse tiles**: a TILE_OFFSETS entry whose 40-bit offset field equals `NULL_TILE` (`0xFFFFFFFFFF`) indicates an absent tile — no compressed bytes on disk at that grid cell. opentile-go returns `(nil, ErrSparseTile)` wrapped in `TileError` so consumers can distinguish "no data here" from "I/O error" or "out of bounds." The cervix fixture has zero sparse tiles; synthetic tests cover the path.
@@ -36,7 +36,7 @@ Cervix is a **2× downsampled** export from the Iris reference encoder (full-res
 | `TileReader` streaming | ✅ via `io.NewSectionReader` |
 | `Tiles` iterator (row-major, serial) | ✅ |
 | Three encoding values exposed via `Compression()` | ✅ | JPEG → `CompressionJPEG`; AVIF → `CompressionAVIF` (new); IRIS → `CompressionIRIS` (new) |
-| METADATA block parsing | ✅ since v0.8 metadata closeout | `Tiler.Metadata().Magnification` from the header f32. `ife.MetadataOf(tiler)` exposes `MicronsPerPixel`, `MagnificationFromHeader`, `CodecMajor/Minor/Build`, `AttributesFormat`, `AttributesVersion`, and the free-form `Attributes map[string]string` |
+| METADATA block parsing | ✅ since v0.8 metadata closeout | `Tiler.Metadata().Magnification` / `.MPP` are the **full-resolution L0** values derived from the scale-relative header per the [resolution convention](#resolution-convention--header-values-are-scale-relative-v0541-81). `ife.MetadataOf(tiler)` exposes `MagnificationFromHeader` (raw coefficient), `MPPFromHeader` (raw scale-1 MPP), `CodecMajor/Minor/Build`, `AttributesFormat`, `AttributesVersion`, and the free-form `Attributes map[string]string` |
 | ATTRIBUTES (free-form key/value map) | ✅ FREE_TEXT (format=1) only | DICOM attributes (format=2) explicitly rejected — no fixture exercises that path. Cervix carries 24 entries (`aperio.*` / `tiff.*` from a re-encoded GT450 SVS); IFE doesn't reserve attribute keys, so vendors set freely |
 | ICC profile passthrough | ✅ | `Tiler.ICCProfile()` returns the raw bytes. Cervix carries 6064 bytes |
 | Associated images (IMAGE_ARRAY) | ✅ | `s.AssociatedImages()` returns label / overview / thumbnail / macro / map / probability with normalised type names (v0.15+). Unknown titles surface lowercased. Per-image `Compression()` follows the spec's **`IMAGE_ENCODING` enum** (distinct from the tile `ENCODING` enum where 1=IRIS): PNG (encoding=1) → `CompressionPNG`, JPEG (2) → `CompressionJPEG`, AVIF (3) → `CompressionAVIF`. PNG associated images decode via the standard library (`internal/assocdecode`, pure-Go — so they decode even under `nocgo`), so `Decode()` works for all three encodings (#74). Cervix has one 1920×1337 JPEG thumbnail |
@@ -97,11 +97,22 @@ IFE's METADATA segment carries IFE-spec-canonical attributes. v0.17 surfaces the
 
 | IFE METADATA source | cross-format Metadata position |
 |---|---|
-| `MPP` attribute (per axis) | `MPP.X`/`MPP.Y`; `MPP.Symmetric()` non-zero when X == Y (cervix fixture is isotropic at 16.835) |
-| objective magnification (when present) | `Magnification` |
+| `micronsPerPixel` (MPP **at scale 1**) ÷ max_scale | `MPP.X`/`MPP.Y` (full-resolution L0); `MPP.Symmetric()` non-zero when X == Y (IFE is always isotropic). Raw header value in `ife.Metadata.MPPFromHeader` |
+| `magnification` (a **coefficient**) × max_scale | `Magnification` (full-resolution L0). Raw header coefficient in `ife.Metadata.MagnificationFromHeader` |
 | `description` block | `ImageDescription` |
 | every spec-defined attribute | `Properties["iris.<key>"]` (24 attributes on the cervix fixture: e.g., `iris.aperio.AppMag`, `iris.tiff.ImageDescription`, etc.) |
 | `CodecMajor.CodecMinor.CodecBuild` from FILE_HEADER → `"iris/<ver>"` | `Metadata.Writer` (v0.20). ImageDescription (when present) preserves source-scanner attribution, NOT the IFE writer. |
+
+### Resolution convention — header values are scale-relative (v0.54.1, #81)
+
+Iris numbers layers in **reverse** (layer 0 = lowest resolution; see *Layer ordering* above) and the METADATA header stores **scale-relative** quantities, not absolute full-resolution values:
+
+- **`magnification` is a coefficient**, not the objective magnification: `physical_mag(layer) = layer.scale × magnification`. The full-resolution magnification is therefore `magnification × max_scale`.
+- **`micronsPerPixel` is the MPP at scale 1** (the coarsest layer). MPP scales as `1/scale`, so the full-resolution MPP is `micronsPerPixel / max_scale`.
+
+`max_scale` is the **finest** layer's `scale` (the largest value in `LAYER_EXTENTS`, = `api[0].Scale` in opentile-go's native-first order). The reader derives `Metadata.Magnification` and `Metadata.MPP` from these formulas at Open time; the verbatim header values stay available in `ife.Metadata.MagnificationFromHeader` (the coefficient) and `ife.Metadata.MPPFromHeader` (the scale-1 MPP). For the canonical 4-layer ×1/×4/×16/×64 export the header carries coefficient `0.625` and scale-1 MPP `16.835` → `0.625 × 64 = 40×` and `16.835 / 64 = 0.263 µm/px`.
+
+**Non-conformant override.** The local `cervix_2x_jpeg.iris` fixture is a re-laddered export (×1…×256, `max_scale = 256`) whose header still carries the values computed for the *original* `max_scale = 64`, so the convention alone yields a value off by `256/64 = 4×`. When the passed-through `ATTRIBUTES` carry the source scanner's authoritative L0 resolution — discrete `aperio.AppMag` / `aperio.MPP`, or the Aperio `ImageDescription` banner (`…|AppMag = 40|MPP = 0.262968|…`) — those **override** the convention (per-field, independently). Conformant non-Aperio files keep the convention-derived value. This is why the cervix fixture reports `Magnification = 40` / `MPP = 0.262968` (from `aperio.*`) while `MagnificationFromHeader = 0.625` / `MPPFromHeader = 16.835` preserve the raw header.
 
 The cervix fixture's encoder doesn't write `ScannerManufacturer/Model/Serial` METADATA fields, so those cross-format positions remain empty for it. Per Q4 Option B, the format-specific `ife.Metadata.MicronsPerPixel` was retired (the cross-format `MPP.X`/`MPP.Y` fields cover it); `ife.MetadataOf(t)` continues to expose IFE-specific structural fields.
 
@@ -118,6 +129,7 @@ The cervix fixture's encoder doesn't write `ScannerManufacturer/Model/Serial` ME
 ## Known issues + history
 
 - **TILE_TABLE x_extent / y_extent** (T3 gate, v0.8): values match tile counts, not pixels. Reader ignores; `LAYER_EXTENTS` is canonical.
+- **Header magnification/MPP are scale-relative** (#81, v0.54.0 → corrected v0.54.1): the v0.54.0 fix mis-framed the GT450 cervix header as "an encoder stamped a downsampled level's value" and preferred `aperio.*` as a special case. The actual Iris convention is that `magnification` is a coefficient and `micronsPerPixel` is the MPP at scale 1 (verified by range-probing the canonical 4-layer `425248_JPEG.iris` reference file, whose header carries `magnification = 0.625 = 40/64` and `micronsPerPixel = 16.835 = 0.262968 × 64`). v0.54.1 reads the convention (`× / ÷ max_scale`) as the primary path; the `aperio.*` override now handles only the *non-conformant* re-laddered local cervix fixture. See [Resolution convention](#resolution-convention--header-values-are-scale-relative-v0541-81).
 - **Self-contained tile bytes** (T8 implementation, v0.8): each tile is a complete JPEG / AVIF / IRIS bytestream. No JPEGTables splice — distinct from SVS / BIF abbreviated-scan pattern. Surfaced during smoke testing when the cervix tile bytes started with full `ff d8 ff e0 ... JFIF` prefixes rather than the SVS-style truncated SOS.
 
 See [`docs/deferred.md`](../deferred.md) §8b (v0.8 retirement audit) for the full mid-task discovery log + per-task gate outcomes.

--- a/formats/ife/metadata.go
+++ b/formats/ife/metadata.go
@@ -83,18 +83,21 @@ func (a AttributesFormat) String() string {
 type Metadata struct {
 	opentile.Metadata
 
-	// MagnificationFromHeader is the level-0 magnification from the
-	// METADATA block's f32 magnification field. 0 when unset.
-	// Available separately from opentile.Metadata.Magnification so
-	// callers that prefer the header value over an Attributes-derived
-	// override can reach it directly.
+	// MagnificationFromHeader is the RAW value of the METADATA block's f32
+	// magnification field. 0 when unset. Per the Iris spec this is a
+	// COEFFICIENT, not an absolute magnification: physical_mag(layer) =
+	// layer.scale × magnification, so the full-resolution magnification is
+	// magnification × max_scale (see opentile.Metadata.Magnification, which
+	// carries that derived value). Available separately so callers can reach
+	// the verbatim header coefficient.
 	MagnificationFromHeader float32
 
-	// MPPFromHeader is the microns-per-pixel from the METADATA block's f32
-	// field (widened to f64), before any Attributes-derived L0 correction.
-	// Zero when unset. Parallels MagnificationFromHeader: when an encoder
-	// stamped a reduced level's MPP into the header (GH #81), opentile.Metadata.MPP
-	// carries the corrected L0 value and this field carries the raw header value.
+	// MPPFromHeader is the RAW microns-per-pixel from the METADATA block's f32
+	// field (widened to f64). Zero when unset. Per the Iris spec this is the
+	// MPP at scale 1 (the coarsest layer), so the full-resolution MPP is
+	// micronsPerPixel / max_scale (carried by opentile.Metadata.MPP). Parallels
+	// MagnificationFromHeader: this field is the verbatim header value before
+	// the resolution-convention derivation and any aperio override (GH #81).
 	MPPFromHeader opentile.MPP
 
 	// CodecMajor / CodecMinor / CodecBuild identify the version of
@@ -126,7 +129,11 @@ type Metadata struct {
 //
 // Returns the IFE Metadata + the associated images slice + the ICC
 // profile bytes (or nil).
-func readMetadata(r io.ReaderAt, off uint64, fileSize int64) (Metadata, []opentile.AssociatedImage, []byte, error) {
+//
+// maxScale is the finest layer's scale (the largest LAYER_EXTENTS scale =
+// api[0].Scale), needed to resolve the header's scale-relative magnification /
+// MPP into full-resolution values — see applyResolutionConvention.
+func readMetadata(r io.ReaderAt, off uint64, fileSize int64, maxScale float64) (Metadata, []opentile.AssociatedImage, []byte, error) {
 	var md Metadata
 	if int64(off)+metadataBlockSize > fileSize {
 		return md, nil, nil, fmt.Errorf("ife: METADATA off 0x%x past EOF", off)
@@ -159,16 +166,20 @@ func readMetadata(r io.ReaderAt, off uint64, fileSize int64) (Metadata, []openti
 	// annotations_offset at 40:48 — read for forward-compat but not parsed in v0.8.
 	mppF32 := math.Float32frombits(binary.LittleEndian.Uint32(buf[48:52]))
 	md.MagnificationFromHeader = math.Float32frombits(binary.LittleEndian.Uint32(buf[52:56]))
-	md.Magnification = float64(md.MagnificationFromHeader)
 
 	// v0.17 cross-format MPP: the IFE METADATA block carries a single
 	// f32 microns_per_pixel value applied to both axes — the spec
-	// doesn't allow anisotropic pixels. Widen f32→f64 (lossless).
+	// doesn't allow anisotropic pixels. Widen f32→f64 (lossless). This is
+	// the RAW header value (MPP at scale 1); the convention below derives
+	// the full-resolution MPP from it.
 	if mppF32 > 0 {
-		md.MPP = opentile.MPP{X: float64(mppF32), Y: float64(mppF32)}
+		md.MPPFromHeader = opentile.MPP{X: float64(mppF32), Y: float64(mppF32)}
 	}
-	// Raw header MPP, before any GH #81 Attributes-derived L0 correction below.
-	md.MPPFromHeader = md.MPP
+
+	// Iris convention: the METADATA header stores scale-relative quantities,
+	// not absolute L0 values — magnification is a coefficient and MPP is at
+	// scale 1. Derive the full-resolution Magnification/MPP from max_scale.
+	applyResolutionConvention(&md, maxScale)
 
 	if attrsOff != NullOffset && attrsOff != 0 {
 		fmtType, ver, kvs, err := readAttributes(r, attrsOff, fileSize)
@@ -194,14 +205,16 @@ func readMetadata(r io.ReaderAt, off uint64, fileSize int64) (Metadata, []openti
 		//     reaching back into md.Attributes.
 		populateIFECrossFields(&md.Metadata, kvs)
 
-		// GH #81: some encoders (observed on GT450-sourced .iris) stamp a
-		// REDUCED level's magnification/MPP into the L0 METADATA header (e.g.
-		// header MPP 16.835 = 2^6 × the true 0.262968 GT450 scan; magnification
-		// 0.625 = 40/64). When the passed-through ATTRIBUTES carry the source
-		// scanner's authoritative L0 values — aperio.AppMag / aperio.MPP, or the
-		// Aperio ImageDescription banner — prefer those for the cross-format
-		// Magnification/MPP. The raw header values stay in MagnificationFromHeader
-		// / MPPFromHeader. Non-Aperio IFE (no such attributes) keeps the header.
+		// GH #81: the spec-correct convention above resolves conformant files
+		// (full_mag = coefficient × max_scale; full_MPP = mpp_at_scale1 /
+		// max_scale). Some NON-conformant encoders mis-ladder the pyramid (our
+		// cervix_2x fixture re-laddered ×64→×256 while keeping header values
+		// computed for the original max_scale), so the convention alone yields a
+		// wrong L0. When the passed-through ATTRIBUTES carry the source scanner's
+		// authoritative L0 values — aperio.AppMag / aperio.MPP, or the Aperio
+		// ImageDescription banner — they OVERRIDE the convention. The raw header
+		// values stay in MagnificationFromHeader / MPPFromHeader. Conformant
+		// non-Aperio IFE (no such attributes) keeps the convention-derived value.
 		if appMag, mpp, okMag, okMPP := aperioL0Resolution(kvs, md.ImageDescription); okMag || okMPP {
 			if okMag {
 				md.Magnification = appMag
@@ -235,10 +248,42 @@ func readMetadata(r io.ReaderAt, off uint64, fileSize int64) (Metadata, []openti
 	return md, assoc, icc, nil
 }
 
+// applyResolutionConvention sets the cross-format L0 Magnification/MPP from the
+// raw IFE METADATA header values per the Iris convention, given maxScale (the
+// finest layer's scale = the largest LAYER_EXTENTS scale = api[0].Scale).
+//
+// Iris numbers layers in REVERSE (layer 0 = lowest resolution) and the METADATA
+// header stores SCALE-RELATIVE quantities, not absolute full-resolution values:
+//
+//   - magnification is a COEFFICIENT: physical_mag(layer) = layer.scale ×
+//     magnification, so the full-resolution magnification is
+//     magnification × max_scale.
+//   - micronsPerPixel is the MPP at scale 1 (the coarsest layer). MPP scales as
+//     1/scale, so the full-resolution MPP is micronsPerPixel / max_scale.
+//
+// (Iris-Headers/include/IrisTypes.hpp; Iris-File-Extension's
+// examples/slide_info_abstraction.cpp.) No-op when maxScale ≤ 0 or the header
+// field is unset (the value stays zero).
+func applyResolutionConvention(md *Metadata, maxScale float64) {
+	if maxScale <= 0 {
+		return
+	}
+	if md.MagnificationFromHeader > 0 {
+		md.Magnification = float64(md.MagnificationFromHeader) * maxScale
+	}
+	if !md.MPPFromHeader.IsZero() {
+		md.MPP = opentile.MPP{
+			X: md.MPPFromHeader.X / maxScale,
+			Y: md.MPPFromHeader.Y / maxScale,
+		}
+	}
+}
+
 // aperioL0Resolution extracts the source scanner's true level-0 AppMag and MPP
-// from the passed-through ATTRIBUTES, used to correct the IFE METADATA header
-// when an encoder stamped a reduced level's magnification/MPP there (GH #81;
-// observed on GT450-sourced .iris). Prefers the discrete aperio.AppMag /
+// from the passed-through ATTRIBUTES. It OVERRIDES the scale-relative convention
+// (applyResolutionConvention) for NON-conformant files whose header values don't
+// match the pyramid's max_scale — e.g. the re-laddered cervix_2x fixture (GH #81;
+// GT450-sourced .iris). Prefers the discrete aperio.AppMag /
 // aperio.MPP keys; falls back to the Aperio ImageDescription banner
 // ("…|AppMag = 40|MPP = 0.262968|…"). okMag/okMPP report which were found;
 // returns all-false when no authoritative source is present (non-Aperio IFE).

--- a/formats/ife/metadata_test.go
+++ b/formats/ife/metadata_test.go
@@ -22,6 +22,13 @@ type metadataBuilder struct {
 	attrs                              []kv         // ATTRIBUTES (FREE_TEXT) — empty means omit the block
 	images                             []synthImage // IMAGE_ARRAY
 	icc                                []byte       // ICC_PROFILE bytes
+	// layers is the LAYER_EXTENTS ladder, COARSEST-FIRST (ascending scale,
+	// as the file stores it). Empty defaults to a single 1×1 scale-1 layer
+	// (so the metadata-only tests that don't care about the pyramid are
+	// unaffected). The finest layer's scale is the convention's max_scale.
+	// Reuses synthLayer from synthetic_test.go; its tiles field is unused
+	// here (every tile points at one shared blob).
+	layers []synthLayer
 }
 
 type kv struct {
@@ -46,11 +53,20 @@ type synthImage struct {
 // raw bytes when something goes wrong. Tile bytes are arbitrary
 // recognizable patterns; no real codec is invoked.
 func (mb *metadataBuilder) build() []byte {
+	layers := mb.layers
+	if len(layers) == 0 {
+		layers = []synthLayer{{xTiles: 1, yTiles: 1, scale: 1}}
+	}
+	var totalTiles uint64
+	for _, ly := range layers {
+		totalTiles += uint64(ly.xTiles) * uint64(ly.yTiles)
+	}
+
 	const ttOff = uint64(fileHeaderSize)
 	leOff := ttOff + uint64(tileTableSize)
-	leSize := uint64(blockHeaderValidation) + uint64(layerExtentEntrySize)
+	leSize := uint64(blockHeaderValidation) + uint64(len(layers))*uint64(layerExtentEntrySize)
 	toOff := leOff + leSize
-	toSize := uint64(blockHeaderValidation) + uint64(tileEntrySize) // 1 tile
+	toSize := uint64(blockHeaderValidation) + totalTiles*uint64(tileEntrySize)
 	tileBytesOff := toOff + toSize
 	tileBytes := []byte("TILE")
 	mdOff := tileBytesOff + uint64(len(tileBytes))
@@ -116,30 +132,36 @@ func (mb *metadataBuilder) build() []byte {
 	binary.LittleEndian.PutUint64(tt[20:28], toOff)
 	binary.LittleEndian.PutUint64(tt[28:36], leOff)
 
-	// LAYER_EXTENTS — one 1×1 layer, scale 1.
+	// LAYER_EXTENTS — coarsest-first (ascending Scale).
 	le := out[leOff : leOff+leSize]
 	binary.LittleEndian.PutUint64(le[0:8], leOff)
 	binary.LittleEndian.PutUint16(le[10:12], layerExtentEntrySize)
-	binary.LittleEndian.PutUint32(le[12:16], 1)
-	base := blockHeaderValidation
-	binary.LittleEndian.PutUint32(le[base:base+4], 1)
-	binary.LittleEndian.PutUint32(le[base+4:base+8], 1)
-	binary.LittleEndian.PutUint32(le[base+8:base+12], math.Float32bits(1))
+	binary.LittleEndian.PutUint32(le[12:16], uint32(len(layers)))
+	for i, ly := range layers {
+		b := blockHeaderValidation + i*int(layerExtentEntrySize)
+		binary.LittleEndian.PutUint32(le[b:b+4], ly.xTiles)
+		binary.LittleEndian.PutUint32(le[b+4:b+8], ly.yTiles)
+		binary.LittleEndian.PutUint32(le[b+8:b+12], math.Float32bits(ly.scale))
+	}
 
-	// TILE_OFFSETS.
+	// TILE_OFFSETS — one entry per tile across all layers; every entry
+	// points at the same shared tile blob (the metadata tests never decode).
 	to := out[toOff : toOff+toSize]
 	binary.LittleEndian.PutUint64(to[0:8], toOff)
 	binary.LittleEndian.PutUint16(to[10:12], tileEntrySize)
-	binary.LittleEndian.PutUint32(to[12:16], 1)
+	binary.LittleEndian.PutUint32(to[12:16], uint32(totalTiles))
 	body := to[blockHeaderValidation:]
-	body[0] = byte(tileBytesOff)
-	body[1] = byte(tileBytesOff >> 8)
-	body[2] = byte(tileBytesOff >> 16)
-	body[3] = byte(tileBytesOff >> 24)
-	body[4] = byte(tileBytesOff >> 32)
-	body[5] = byte(len(tileBytes))
-	body[6] = byte(len(tileBytes) >> 8)
-	body[7] = byte(len(tileBytes) >> 16)
+	for k := uint64(0); k < totalTiles; k++ {
+		o := k * uint64(tileEntrySize)
+		body[o+0] = byte(tileBytesOff)
+		body[o+1] = byte(tileBytesOff >> 8)
+		body[o+2] = byte(tileBytesOff >> 16)
+		body[o+3] = byte(tileBytesOff >> 24)
+		body[o+4] = byte(tileBytesOff >> 32)
+		body[o+5] = byte(len(tileBytes))
+		body[o+6] = byte(len(tileBytes) >> 8)
+		body[o+7] = byte(len(tileBytes) >> 16)
+	}
 
 	copy(out[tileBytesOff:], tileBytes)
 
@@ -363,6 +385,64 @@ func TestMetadataBuilderRoundtrip(t *testing.T) {
 	}
 	if v, ok := ifeMD.Attributes["empty.value"]; !ok || v != "" {
 		t.Errorf("empty.value: ok=%v val=%q", ok, v)
+	}
+}
+
+// TestResolutionConventionConformant verifies the Iris resolution convention on
+// a spec-CONFORMANT synthetic file (no aperio override). Iris numbers layers in
+// REVERSE (layer 0 = lowest resolution) and the METADATA header stores
+// scale-relative quantities, NOT absolute L0 values:
+//
+//   - magnification is a COEFFICIENT: physical_mag(layer) = layer.scale × coefficient.
+//   - micronsPerPixel is the MPP at scale 1 (the coarsest layer).
+//
+// The full-resolution (finest layer) values therefore derive from the largest
+// LAYER_EXTENTS scale (max_scale = api[0].Scale):
+//
+//	full_mag = coefficient × max_scale
+//	full_MPP = mpp_at_scale1 / max_scale
+//
+// Here: 4 layers ×1/×4/×16/×64 (max_scale 64), header coefficient 0.625 and
+// scale-1 MPP 16.0 → full-res 40× and 0.25 µm/px. All values are exact in
+// IEEE-754 binary32 so the assertions can use ==.
+func TestResolutionConventionConformant(t *testing.T) {
+	mb := &metadataBuilder{
+		codecMajor: 2025, codecMinor: 1, codecBuild: 0,
+		mpp:           16.0,  // MPP at scale 1; full-res = 16.0 / 64 = 0.25
+		magnification: 0.625, // coefficient; full-res = 0.625 × 64 = 40
+		layers: []synthLayer{
+			{xTiles: 1, yTiles: 1, scale: 1},  // coarsest (api L3)
+			{xTiles: 1, yTiles: 1, scale: 4},  // api L2
+			{xTiles: 1, yTiles: 1, scale: 16}, // api L1
+			{xTiles: 1, yTiles: 1, scale: 64}, // finest (api L0) → max_scale
+		},
+		// No aperio.* attributes → the convention is authoritative.
+	}
+	data := mb.build()
+	tiler, err := openIFE(bytes.NewReader(data), int64(len(data)), &format.Config{})
+	if err != nil {
+		t.Fatalf("openIFE: %v", err)
+	}
+	defer tiler.Close()
+
+	cm := tiler.Metadata()
+	if cm.Magnification != 40 {
+		t.Errorf("Magnification = %v, want 40 (coefficient 0.625 × max_scale 64)", cm.Magnification)
+	}
+	if cm.MPP.X != 0.25 || cm.MPP.Y != 0.25 {
+		t.Errorf("MPP = %v/%v, want 0.25/0.25 (header 16.0 / max_scale 64)", cm.MPP.X, cm.MPP.Y)
+	}
+
+	ifeMD, ok := MetadataOf(tiler)
+	if !ok {
+		t.Fatal("MetadataOf !ok")
+	}
+	// The raw header values (coefficient + scale-1 MPP) stay available verbatim.
+	if ifeMD.MagnificationFromHeader != 0.625 {
+		t.Errorf("MagnificationFromHeader = %v, want raw header coefficient 0.625", ifeMD.MagnificationFromHeader)
+	}
+	if ifeMD.MPPFromHeader.X != 16.0 || ifeMD.MPPFromHeader.Y != 16.0 {
+		t.Errorf("MPPFromHeader = %v/%v, want raw header 16.0/16.0", ifeMD.MPPFromHeader.X, ifeMD.MPPFromHeader.Y)
 	}
 }
 

--- a/formats/ife/tiler.go
+++ b/formats/ife/tiler.go
@@ -51,12 +51,19 @@ func openIFE(r io.ReaderAt, size int64, _ *format.Config) (format.Reader, error)
 		apiOrder[len(fileOrder)-1-i] = le
 	}
 
-	// Optional metadata block; absent on minimal synthetic files.
+	// Optional metadata block; absent on minimal synthetic files. The
+	// finest layer's scale (max_scale = api[0].Scale, the largest scale)
+	// lets readMetadata resolve the header's scale-relative magnification /
+	// MPP into full-resolution values.
+	var maxScale float64
+	if len(apiOrder) > 0 {
+		maxScale = float64(apiOrder[0].Scale)
+	}
 	var md Metadata
 	var assoc []opentile.AssociatedImage
 	var icc []byte
 	if hdr.MetadataOffset != NullOffset && hdr.MetadataOffset != 0 {
-		md, assoc, icc, err = readMetadata(r, hdr.MetadataOffset, size)
+		md, assoc, icc, err = readMetadata(r, hdr.MetadataOffset, size, maxScale)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
## Summary

Follow-up correcting the v0.54.0 fix for #81. v0.54.0 mis-framed the root cause as *"an encoder stamped a downsampled level's value into the L0 header"* and made the `aperio.AppMag` / `aperio.MPP` lookup the **primary** path. That would surface a **wrong** `Magnification` / `MPP` for any future *conformant* `.iris` file that has no aperio attributes.

The actual Iris convention — verified by range-probing the canonical 4-layer ×1/×4/×16/×64 `425248_JPEG.iris` reference (header `magnification = 0.625 = 40/64`, `micronsPerPixel = 16.835 = 0.262968 × 64`) — is that Iris numbers layers in **reverse** (layer 0 = lowest resolution) and the `METADATA` header stores **scale-relative** quantities:

- `magnification` is a **coefficient**: `physical_mag(layer) = layer.scale × magnification`
- `micronsPerPixel` is the **MPP at scale 1** (the coarsest layer)

opentile-go now derives the full-resolution values from the finest layer's scale (`max_scale = api[0].Scale`):

```
Magnification = magnification × max_scale
MPP           = micronsPerPixel / max_scale
```

The `aperio.*` (or `ImageDescription` banner) lookup is retained as an **override** for *non-conformant* files only — specifically the local `cervix_2x_jpeg.iris` fixture, a re-laddered ×1…×256 export whose header still holds values computed for the original `max_scale = 64` (off by `256/64 = 4×` under the convention). Conformant non-Aperio IFE now resolves with no attributes needed. Raw header values stay in `MagnificationFromHeader` / `MPPFromHeader`.

## Changes

- `applyResolutionConvention(md, maxScale)` derives full-res `Magnification`/`MPP`; `readMetadata` takes `maxScale` (from `api[0].Scale`).
- `aperioL0Resolution` demoted from primary path to non-conformant override (logic unchanged; comments/docs corrected).
- New `TestResolutionConventionConformant` — synthetic 4-layer ×1/×4/×16/×64 file, no aperio, asserts `0.625 × 64 = 40` and `16.0 / 64 = 0.25`; metadata builder extended to lay out a multi-layer ladder.
- Docs: `docs/formats/ife.md` (reversed numbering, scale-relative semantics, derivation, override) + the local byte-layout spec.

## Test Plan

- [x] `go test ./formats/ife/ -race` green (incl. new conformant test)
- [x] `OPENTILE_TESTDIR=… go test ./formats/ife ./tests/parity` green — cervix fixture still reports `Magnification = 40` / `MPP = 0.262968` via the override; `MagnificationFromHeader = 0.625` / `MPPFromHeader = 16.835` preserved
- [x] `go vet` / `go build ./...` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)