### PR TITLE
feat(opentile): caller-chosen display tile size — render square tiles from non-square BIF

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,33 @@ The single source of truth for "what was deferred and why" is
 front-page summary; the deferred file has the full reasoning,
 upstream references, and retirement audit per milestone.
 
+## [0.57.0] — 2026-06-25
+
+Caller-chosen display tile size — render uniform/square display tiles from
+formats that store non-square tiles (legacy BIF).
+
+### Added
+
+- **`Level.StitchedGridFor(tile Size) Size`** — `StitchedGrid` for a caller-chosen
+  display tile size (`ceil(Size/tile)`), so a viewer can render uniform/square
+  display tiles independent of the stored `TileSize`.
+- **`Level.StitchedTileInto` now uses the dst's dimensions as the display tile
+  size** on **overlapping** levels (stitched BIF). The composite is region-based,
+  so dst may be any size — a viewer can render e.g. 512×512 display tiles even
+  though legacy BIF stores **non-square 1024×1360** tiles (which choke renderers
+  that assume square). The result is pixel-identical to `ReadRegion` over
+  `[tx*dst.W, ty*dst.H, dst.W, dst.H]`, and the per-source-tile decode-once frame
+  cache still applies. Pair it with `StitchedGridFor(dstSize)`. Existing callers
+  passing a `TileSize`-sized dst are unchanged.
+
+### Notes
+
+- Scoped to **overlapping** levels (BIF). Non-overlapping formats store square
+  tiles and keep the existing fast path: `StitchedTileInto` there still behaves
+  like `DecodedTileInto` (dst must equal `TileSize`); use `ReadRegion` for an
+  arbitrary rectangle. `StitchedTile` / `StitchedGrid` (the `TileSize`-default
+  convenience forms) are unchanged.
+
 ## [0.56.0] — 2026-06-25
 
 BIF reduced pyramid levels are stitched via the openslide subtile model — DP

--- a/docs/formats/bif.md
+++ b/docs/formats/bif.md
@@ -79,6 +79,16 @@ overlapping tiles for faithful transcoding. `StitchedTile` requires a decoder
 for the level's codec and does not support `Scale > 1` (use the pyramid's
 `ReadRegionScaled` / `ScaledStrips` for scaled traversal).
 
+**Non-square tiles + caller-chosen display size (v0.57.0).** Legacy iScan stores
+**non-square 1024×1360** tiles (DP 200 is square 1024×1024), which choke viewers
+that assume square display tiles. Since `StitchedTile` composites region-by-region,
+the display tile size need not match storage: `StitchedTileInto(tx, ty, dst)` uses
+**dst's own dimensions** as the display tile size on overlapping levels, so a
+viewer can render uniform/square tiles (e.g. 512×512) regardless of the stored
+`TileSize`. Iterate `level.StitchedGridFor(tile)` (`== ceil(Size/tile)`) instead of
+`StitchedGrid()`. The output is pixel-identical to `ReadRegion` over the tile's
+rectangle, with the decode-once frame cache still in effect.
+
 ### DP generation (VENTANA DP 200 / DP 600) — pixel-exact stitching
 
 Spec-compliant DP slides carry per-tile-pair overlap values in the `<EncodeInfo>/<SlideStitchInfo>/<ImageInfo>/<TileJointInfo>` XMP elements. opentile-go computes the stitched layout from these joints using the algorithm described in the **Roche BIF whitepaper** (v1.0, 2020, MC--06058 1120, §"Image stitching process", page 15): each confident (FlagJoined, Confidence=100) joint shifts the right/lower tile inward by its OverlapX/OverlapY; the stitched extent is the convex hull of all resulting tile placements.

--- a/formats/bif/display_tile_size_test.go
+++ b/formats/bif/display_tile_size_test.go
@@ -1,0 +1,97 @@
+package bif_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	opentile "github.com/wsilabs/opentile-go"
+	"github.com/wsilabs/opentile-go/decoder"
+	_ "github.com/wsilabs/opentile-go/decoder/all"
+	_ "github.com/wsilabs/opentile-go/formats/all"
+)
+
+// TestStitchedDisplayTileCustomSize verifies a consumer can render BIF display
+// tiles at a caller-chosen size (e.g. square 512×512) independent of the level's
+// stored TileSize — legacy BIF stores non-square 1024×1360 tiles, which choke
+// viewers that assume square. StitchedGridFor(tile) gives the iteration grid and
+// StitchedTileInto with a `tile`-sized dst composites the matching rectangle —
+// pixel-identical to ReadRegion of the same rect.
+func TestStitchedDisplayTileCustomSize(t *testing.T) {
+	for _, fx := range []string{"Ventana-1.bif", "OS-1.bif"} {
+		t.Run(fx, func(t *testing.T) {
+			path := "/Volumes/Ext/GitHub/opentile-go/sample_files/bif/" + fx
+			if dir := os.Getenv("OPENTILE_TESTDIR"); dir != "" {
+				path = filepath.Join(dir, "bif", fx)
+			}
+			if _, err := os.Stat(path); err != nil {
+				t.Skip(fx + " absent")
+			}
+			s, err := opentile.OpenFile(path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer s.Close()
+			l, err := s.Level(1) // an overlapping reduced level
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !l.Overlapping {
+				t.Fatal("L1 not overlapping")
+			}
+
+			disp := opentile.Size{W: 512, H: 512} // square, != stored TileSize
+			grid := l.StitchedGridFor(disp)
+			wantGrid := opentile.Size{
+				W: (l.Size.W + disp.W - 1) / disp.W,
+				H: (l.Size.H + disp.H - 1) / disp.H,
+			}
+			if grid != wantGrid {
+				t.Errorf("StitchedGridFor(%v) = %v, want %v", disp, grid, wantGrid)
+			}
+
+			// A few interior display tiles must equal ReadRegion of the same rect.
+			for _, c := range [][2]int{{grid.W / 3, grid.H / 3}, {grid.W / 2, grid.H / 2}} {
+				tx, ty := c[0], c[1]
+				dst := decoder.NewImageFormat(disp.W, disp.H, decoder.PixelFormatRGB)
+				if err := l.StitchedTileInto(tx, ty, dst); err != nil {
+					t.Fatalf("StitchedTileInto(%d,%d) 512×512: %v", tx, ty, err)
+				}
+				region, err := l.ReadRegion(opentile.Region{
+					Origin: opentile.Point{X: tx * disp.W, Y: ty * disp.H},
+					Size:   disp,
+				}, opentile.WithFormat(decoder.PixelFormatRGB))
+				if err != nil {
+					t.Fatal(err)
+				}
+				if mad := exactMAD(dst, region); mad != 0 {
+					t.Errorf("display tile (%d,%d): StitchedTileInto != ReadRegion (MAD %.2f)", tx, ty, mad)
+				}
+			}
+		})
+	}
+}
+
+func exactMAD(a, b *decoder.Image) float64 {
+	if a.Width != b.Width || a.Height != b.Height {
+		return 1e9
+	}
+	bpp := 3
+	if a.Format == decoder.PixelFormatRGBA {
+		bpp = 4
+	}
+	var sum, n float64
+	for y := 0; y < a.Height; y++ {
+		for x := 0; x < a.Width; x++ {
+			for c := 0; c < 3; c++ {
+				d := int(a.Pix[y*a.Stride+x*bpp+c]) - int(b.Pix[y*b.Stride+x*bpp+c])
+				if d < 0 {
+					d = -d
+				}
+				sum += float64(d)
+				n++
+			}
+		}
+	}
+	return sum / n
+}

--- a/level_reads.go
+++ b/level_reads.go
@@ -111,11 +111,19 @@ func (l *Level) StitchedTile(tx, ty int, opts ...DecodeOption) (*decoder.Image, 
 }
 
 // StitchedTileInto is the allocation-free form of StitchedTile: it composites
-// the display tile (tx, ty) into the caller-provided dst, which must be exactly
-// the level's TileSize. The composite is done in dst's own pixel format, and
-// dst is white-filled before compositing. Reuse one dst across a display-grid
-// traversal to avoid a per-tile allocation. Returns an error if dst is nil or
-// not TileSize. Behaves exactly like DecodedTileInto for non-overlapping levels.
+// the display tile (tx, ty) into the caller-provided dst. The composite is done
+// in dst's own pixel format, and dst is white-filled before compositing. Reuse
+// one dst across a display-grid traversal to avoid a per-tile allocation.
+//
+// The DISPLAY TILE SIZE is dst's own dimensions: for an OVERLAPPING level
+// (stitched BIF) the composite is region-based, so dst may be any size — a
+// viewer can render uniform/square display tiles (e.g. 512×512) even though the
+// level stores non-square tiles (legacy BIF is 1024×1360). Pair it with
+// StitchedGridFor(dstSize) for the matching iteration grid; the result is
+// pixel-identical to ReadRegion over [tx*dst.W, ty*dst.H, dst.W, dst.H]. For a
+// NON-overlapping level it behaves like DecodedTileInto, so dst must be the
+// level's TileSize (retiling other formats to a custom size is not in scope —
+// they store square tiles; use ReadRegion for an arbitrary rectangle).
 func (l *Level) StitchedTileInto(tx, ty int, dst *decoder.Image, opts ...DecodeOption) error {
 	return l.slide.imageStitchedTileInto(l.PyramidIndex, l.Index, tx, ty, dst, opts...)
 }
@@ -128,5 +136,22 @@ func (l *Level) StitchedGrid() Size {
 	return Size{
 		W: ceilDiv(l.Size.W, l.TileSize.W),
 		H: ceilDiv(l.Size.H, l.TileSize.H),
+	}
+}
+
+// StitchedGridFor is StitchedGrid for a caller-chosen display tile size:
+// ceil(Size/tile) per axis. Iterate it with StitchedTileInto using a tile-sized
+// dst to render display tiles at a uniform/square size independent of the stored
+// (possibly non-square) TileSize — e.g. legacy BIF stores 1024×1360 but a viewer
+// can render 512×512. The caller-chosen size is honored on overlapping levels;
+// on non-overlapping levels StitchedTileInto still requires dst == TileSize, so
+// use StitchedGrid there. Returns the zero Size for a non-positive tile.
+func (l *Level) StitchedGridFor(tile Size) Size {
+	if tile.W <= 0 || tile.H <= 0 {
+		return Size{}
+	}
+	return Size{
+		W: ceilDiv(l.Size.W, tile.W),
+		H: ceilDiv(l.Size.H, tile.H),
 	}
 }

--- a/stitched_tile.go
+++ b/stitched_tile.go
@@ -115,13 +115,17 @@ func (s *Slide) imageStitchedTileInto(image, level, tx, ty int, dst *decoder.Ima
 	if newDecodeConfig(opts).scale > 1 {
 		return decoder.ErrUnsupportedScale
 	}
-	tileW, tileH := lvl.TileSize.W, lvl.TileSize.H
-	if dst.Width != tileW || dst.Height != tileH {
-		return fmt.Errorf("opentile: StitchedTileInto: dst is %dx%d, want TileSize %dx%d",
-			dst.Width, dst.Height, tileW, tileH)
+	// The display tile size is dst's own dimensions — the composite is
+	// region-based, so a viewer can render uniform/square display tiles even
+	// when the level stores non-square tiles (legacy BIF is 1024×1360). The
+	// SOURCE compositing unit stays the level's TileSize (the frame cache is
+	// keyed on stored-tile coords); only the output rectangle follows dst.
+	dispW, dispH := dst.Width, dst.Height
+	if dispW <= 0 || dispH <= 0 {
+		return fmt.Errorf("opentile: StitchedTileInto: dst is %dx%d", dispW, dispH)
 	}
-	x0, y0 := tx*tileW, ty*tileH
-	x1, y1 := x0+tileW, y0+tileH
+	x0, y0 := tx*dispW, ty*dispH
+	x1, y1 := x0+dispW, y0+dispH
 	if sw, sh, ok := rl.StitchedSize(level); ok {
 		if x1 > sw {
 			x1 = sw
@@ -140,7 +144,7 @@ func (s *Slide) imageStitchedTileInto(image, level, tx, ty int, dst *decoder.Ima
 	// the format pinned to dst.Format (full-slice cap so the caller's backing
 	// array is never mutated).
 	loadOpts := append(opts[:len(opts):len(opts)], WithFormat(dst.Format))
-	return compositeStitchedLoop(rl, level, x0, y0, x0, y0, x1, y1, tileW, tileH, dst,
+	return compositeStitchedLoop(rl, level, x0, y0, x0, y0, x1, y1, lvl.TileSize.W, lvl.TileSize.H, dst,
 		func(col, row int) (*decoder.Image, error) {
 			key := frameCacheKey{image: image, level: level, col: col, row: row, format: dst.Format}
 			return fc.getOrLoad(key, func() (*decoder.Image, error) {

--- a/stitched_tile_into_test.go
+++ b/stitched_tile_into_test.go
@@ -55,11 +55,24 @@ func TestStitchedTileIntoReuseBuffer(t *testing.T) {
 	}
 }
 
-func TestStitchedTileIntoWrongDims(t *testing.T) {
+// On an overlapping level the dst size IS the display tile size (region-based
+// composite), so a non-TileSize dst is valid — a viewer can render at any
+// uniform/square size. It must match ReadRegion over the same rectangle.
+func TestStitchedTileIntoCustomDisplaySize(t *testing.T) {
 	s := &Slide{r: newFakeStitchReader(), readBudget: 64 << 20}
-	dst := decoder.NewImageFormat(50, 50, decoder.PixelFormatRGB) // not TileSize (100x100)
-	if err := s.imageStitchedTileInto(0, 0, 0, 0, dst); err == nil {
-		t.Fatal("want error for dst that is not TileSize")
+	const disp = 50 // != the fake's TileSize (100×100)
+	dst := decoder.NewImageFormat(disp, disp, decoder.PixelFormatRGB)
+	if err := s.imageStitchedTileInto(0, 0, 1, 1, dst); err != nil {
+		t.Fatalf("custom display size: %v", err)
+	}
+	region := decoder.NewImageFormat(disp, disp, decoder.PixelFormatRGB)
+	if err := s.imageReadRegionInto(0, 0, Point{X: 1 * disp, Y: 1 * disp}, region); err != nil {
+		t.Fatal(err)
+	}
+	for i := range dst.Pix {
+		if dst.Pix[i] != region.Pix[i] {
+			t.Fatalf("display tile pixel %d: StitchedTileInto %d != ReadRegion %d", i, dst.Pix[i], region.Pix[i])
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

Legacy iScan BIF stores **non-square 1024×1360** tiles — the first/only format to do so — which choke viewers (openscope) that assume square display tiles. Since `StitchedTile` composites region-by-region, the display tile size need not match storage.

- **`Level.StitchedGridFor(tile Size) Size`** = `ceil(Size/tile)`.
- **`StitchedTileInto` uses dst's dimensions as the display tile size** on **overlapping** levels (stitched BIF): dst may be any size, so a viewer renders uniform/square display tiles (e.g. 512×512) regardless of the stored `TileSize`. Pixel-identical to `ReadRegion` over `[tx*dst.W, ty*dst.H, dst.W, dst.H]`, with the decode-once frame cache still in effect. Existing `TileSize`-sized callers unchanged.

## Scope (B2 — overlapping only)

Non-overlapping formats store square tiles and keep the `DecodedTileInto` fast path (dst must equal `TileSize` there) — **zero regression risk** for the 10 non-BIF formats. The source compositing unit stays the level's `TileSize` (frame cache keyed on stored-tile coords); only the output rectangle follows dst. `StitchedTile` / `StitchedGrid` (the `TileSize`-default forms) are unchanged.

## Test Plan

- [x] New `TestStitchedDisplayTileCustomSize`: 512×512 square display tiles from Ventana-1 (square 1024×1024) **and** OS-1 (non-square 1024×1360), pixel-identical to `ReadRegion`. `StitchedGridFor` = `ceil(Size/512)`.
- [x] `TestStitchedTileIntoWrongDims` → `TestStitchedTileIntoCustomDisplaySize` (a non-TileSize dst is now valid on overlapping levels).
- [x] Full `go test ./...` green (`-race` on root + bif); `go vet` clean. nocgo build compiles (the local nocgo failures are pre-existing decode tests that skip in CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)