### PR TITLE
feat(bif): multi-AOI legacy iScan stitching (closes #67)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,38 @@ The single source of truth for "what was deferred and why" is
 front-page summary; the deferred file has the full reasoning,
 upstream references, and retirement audit per milestone.
 
+## [0.58.0] — 2026-06-25
+
+Multi-AOI legacy iScan BIF stitching — place every scanned Area of Interest at
+its own slide anchor (closes #67).
+
+### Fixed
+
+- **Legacy iScan BIF multi-AOI placement (#67).** A legacy iScan slide may carry
+  several Areas of Interest (AOIs) — separate scanned tissue regions, each a
+  sub-grid of the global tile grid placed at its own origin (OS-2 has three
+  `AoiOrigin` nodes, one unscanned). `buildLegacyLayout` previously stitched the
+  whole frame grid as a single AOI, which overlaid the disjoint regions and left
+  a visible seam through the large AOI on zoom. Following openslide's Ventana
+  reader, the layout now pairs `ImageInfo[i]` with `AoiOrigin[i]` by document
+  order, skips `AOIScanned=false` AOIs, and places each scanned AOI's local
+  `NumCols×NumRows` grid at its own `(Pos-X, Pos-Y)` anchor (Pos-Y is measured
+  from the AOI bottom, so it is Y-flipped into image space). Within each AOI the
+  existing separable per-gap-average overlap model (#63) is reused. Single-AOI
+  slides (OS-1: one AOI at origin 0) are the degenerate case and remain
+  **byte-identical**. OS-2 L0 now reports the union hull across scanned AOIs
+  (114951×76389) with the inter-AOI seam removed; reduced levels floor-halve.
+
+### Notes
+
+- Per-tile raw/decoded bytes and `Grid` are unchanged (raw frame addressing).
+  Only the stitched placement (`Level.Size`, `ReadRegion`/`ReadRegionScaled`/
+  `ScaledStrips`/`StitchedTile` output) changes, and only for multi-AOI legacy
+  slides. The other 10 formats and DP-generation BIF are untouched.
+- OS-2.bif is a PHI/local-only fixture (gitignored); its committed
+  `OS-2.bif.json` snapshot and the `TestBIFGeometry`/`TestSlideParity` pins are
+  SHA/geometry-only and skip cleanly in CI when the slide is absent.
+
 ## [0.57.0] — 2026-06-25
 
 Caller-chosen display tile size — render uniform/square display tiles from

--- a/docs/formats/bif.md
+++ b/docs/formats/bif.md
@@ -112,6 +112,8 @@ Legacy iScan slides (ScannerModel missing or not prefixed `"VENTANA DP"`) are **
 
 **Algorithm:** For each axis independently, per-gap overlaps are averaged across all live joins (Confidence ≥ 98) touching that column-gap or row-gap, with the global-mean used for gaps that have no qualifying joins. X\[col\] and Y\[row\] are then accumulated left-to-right and top-to-bottom from those average overlaps, giving each tile a placed origin; the stitched extent is the convex hull of all placed frames.
 
+**Multi-AOI (#67).** A legacy slide may carry several **Areas of Interest** — separate scanned tissue regions, each a sub-grid of the global tile grid placed at its own slide origin. OS-2 has three `<AoiOrigin>` nodes (one unscanned); single-AOI slides like OS-1 are the degenerate one-area case. Following openslide's `openslide-vendor-ventana.c` area model, the layout pairs `ImageInfo[i]` with `AoiOrigin[i]` by document order, **skips `AOIScanned=false` AOIs**, and places each scanned AOI's local `NumCols×NumRows` grid at its own anchor: the global-grid start cell is `Origin / TileSize`, the pixel anchor is `(Pos-X, Pos-Y)`, and — because **Pos-Y is measured from the AOI bottom** — the per-AOI top in image space is Y-flipped to `top − Pos-Y − height` (`top` = max over AOIs of `Pos-Y + height`). Within each AOI the per-gap-average overlap model above runs over that AOI's **local** grid (serpentine numbering local to the AOI). The full layout is the union hull across all scanned AOIs, normalized so its top-left corner is `(0,0)`. A single-AOI slide (one area at `Origin=0`, `Pos-X=0`) reduces exactly to the original whole-grid model, so OS-1 is byte-identical.
+
 **Result:** Near-exact vs openslide (the all-4 oracle — bio-formats crashes opening 3 of the 4 legacy fixtures):
 
 | Fixture | opentile-go | openslide |
@@ -128,7 +130,7 @@ Width is clean-room-exact for tested fixtures. Height carries a ~0.05% residual:
 - `TestLegacySeamContinuity`: stitch-band pixel MAD is 2.3–4.5× tighter than naive placement.
 - `TestLegacyDimsVsOpenslide`: dimensions within 0.1% of openslide across all 4 fixtures.
 
-**Multi-AOI untested.** All 4 legacy fixtures are single-AOI; multi-AOI legacy stitching behaviour is unverified.
+**Multi-AOI (#67) — validated on OS-2.** OS-2.bif carries three AOIs (two scanned, one unscanned); the two scanned tissue areas now land at their own `(Pos-X, Pos-Y)` anchors instead of being overlaid as one grid, removing the seam that previously cut through the large AOI on zoom. L0 reports the union hull `114951 × 76389`; reduced levels floor-halve. OS-2 is a PHI/local-only fixture, so its `TestBIFGeometry`/`TestSlideParity` pins are SHA/geometry-only and skip in CI. The remaining `columnYAdjust` height residual (#68) is orthogonal and still applies per-AOI.
 
 ## Edge tile semantics
 

--- a/formats/bif/stitch.go
+++ b/formats/bif/stitch.go
@@ -258,14 +258,24 @@ const legacyConfidenceCutoff = 98
 
 // buildLegacyLayout reconstructs tile placement for legacy iScan BIF (Coreo/HT),
 // which carry no <Frame> nodes — the only position signal is the TileJointInfo
-// overlap graph. The graph is too fragmented to traverse per-tile (Phase 0:
-// ~5% reachable from a root), so we use a SEPARABLE per-axis model derived from
-// the aggregate per-gap overlap statistics (this is #63's recommended
-// "accumulate per-gap", NOT a single global average): tile (col,row) lands at
-// (X[col], Y[row]) where X[]/Y[] accumulate (tile - perGapAvgOverlap) across
-// gaps, in float, with empty gaps taking the global mean overlap. Clean-room —
-// derived from the file's own joints; bio-formats/openslide are test oracles
-// only. Declines (nil → naive) unless this is a legacy slide with live joints.
+// overlap graph plus the per-AOI geometry (origin / Pos / NumCols×NumRows).
+//
+// MULTI-AOI (#67): a legacy slide may carry several Areas of Interest, each a
+// sub-grid of the global tile grid placed at its own origin (OS-2 has 3 AOIs,
+// one unscanned). Following openslide's ventana reader: pair ImageInfo[i] with
+// AoiOrigin[i] by document order, skip AOIScanned=false AOIs, and place each
+// scanned AOI's local NumCols×NumRows grid at (Pos-X, flipped Pos-Y) with
+// start col/row = Origin / tileSize. Pos-Y is measured from the AOI bottom, so
+// it is flipped to image space (top - Pos-Y - height). Single-AOI slides (OS-1)
+// are the degenerate case (one AOI at OriginX=0, Pos-X=0 → lands at origin,
+// byte-identical to before).
+//
+// WITHIN each AOI, placement uses the SEPARABLE per-axis per-gap-average overlap
+// model (#63, localOffsets): tile (c,r) at (Pos-X + X[c], top'+Y[r]) where X/Y
+// accumulate (tile - perGapAvgOverlap) over that AOI's joints (serpentine over
+// its LOCAL grid). Clean-room — derived from the file's own joints; openslide /
+// bio-formats are test oracles only. Declines (nil → naive) unless legacy with
+// live joints.
 func buildLegacyLayout(in StitchInput) *Layout {
 	ei := in.EncodeInfo
 	if in.Generation != GenerationLegacyIScan || ei == nil || len(ei.ImageInfos) == 0 {
@@ -274,9 +284,96 @@ func buildLegacyLayout(in StitchInput) *Layout {
 	if !hasLiveJoint(ei) {
 		return nil
 	}
-	cols, rows, tw, th := in.Cols, in.Rows, in.TileW, in.TileH
+	tw, th := in.TileW, in.TileH
+
+	type area struct {
+		startCol, startRow int   // global-grid offset = Origin / tileSize
+		posX, posY         int   // Pos anchor (Pos-Y measured from the AOI bottom)
+		cols, rows         int   // local grid = NumCols × NumRows
+		x, y               []int // per-gap local offsets (X[0]=Y[0]=0)
+		h                  int   // local pixel height = Y[rows-1] + tileH
+	}
+	var areas []*area
+	for i := range ei.ImageInfos {
+		ii := &ei.ImageInfos[i]
+		if !ii.AOIScanned || ii.NumCols < 1 || ii.NumRows < 1 || i >= len(ei.AoiOrigins) {
+			continue
+		}
+		o := ei.AoiOrigins[i]
+		a := &area{
+			startCol: o.OriginX / tw, startRow: o.OriginY / th,
+			posX: ii.PosX, posY: ii.PosY, cols: ii.NumCols, rows: ii.NumRows,
+		}
+		a.x, a.y = localOffsets(ii, tw, th)
+		a.h = a.y[a.rows-1] + th
+		areas = append(areas, a)
+	}
+	if len(areas) == 0 {
+		return nil
+	}
+
+	// Y-flip (openslide): Pos-Y is the distance from the AOI bottom to a point
+	// below all AOIs, so the per-AOI top in image space is top - Pos-Y - height.
+	top := 0
+	for _, a := range areas {
+		if a.posY+a.h > top {
+			top = a.posY + a.h
+		}
+	}
+
+	l := newLayout(in.Cols, in.Rows, tw, th)
+	minX, minY := 1<<62, 1<<62
+	maxX, maxY := 0, 0
+	for _, a := range areas {
+		ayTop := top - a.posY - a.h
+		for r := 0; r < a.rows; r++ {
+			for c := 0; c < a.cols; c++ {
+				gc, gr := a.startCol+c, a.startRow+r
+				if gc < 0 || gc >= in.Cols || gr < 0 || gr >= in.Rows {
+					continue
+				}
+				x, y := a.posX+a.x[c], ayTop+a.y[r]
+				l.origin[[2]int{gc, gr}] = TilePlacement{Col: gc, Row: gr, X: x, Y: y}
+				if x < minX {
+					minX = x
+				}
+				if y < minY {
+					minY = y
+				}
+				if x+tw > maxX {
+					maxX = x + tw
+				}
+				if y+th > maxY {
+					maxY = y + th
+				}
+			}
+		}
+	}
+	// Normalize the hull's top-left to (0,0). Pos-X and the Y-flip already land
+	// near origin for the slides we have; normalize defensively.
+	if minX != 0 || minY != 0 {
+		for k, p := range l.origin {
+			p.X -= minX
+			p.Y -= minY
+			l.origin[k] = p
+		}
+		maxX -= minX
+		maxY -= minY
+	}
+	l.Width, l.Height = maxX, maxY
+	return l
+}
+
+// localOffsets computes the per-axis cumulative pixel offsets for one AOI's
+// local grid (NumCols×NumRows) via the separable per-gap-average overlap model
+// (#63): X[0]=Y[0]=0; X[c] accumulates (tileW - perColGapAvgOverlap) across this
+// AOI's joints (serpentine over its LOCAL grid), empty gaps taking the AOI's
+// global-mean overlap. A single-AOI slide reduces to the original whole-grid
+// model (local grid == global grid), so OS-1 is unchanged.
+func localOffsets(ii *bifxml.ImageInfo, tw, th int) (X, Y []int) {
+	cols, rows := ii.NumCols, ii.NumRows
 	resolve := func(idx int) (c, r int, ok bool) {
-		c, r = serpentineToImage(idx-1, cols, rows) // legacy: 1-based serpentine
+		c, r = serpentineToImage(idx-1, cols, rows) // 1-based serpentine over the LOCAL grid
 		if c < 0 {
 			return 0, 0, false
 		}
@@ -288,30 +385,28 @@ func buildLegacyLayout(in StitchInput) *Layout {
 	rowN := make([]int, rows)
 	var gXs, gYs float64
 	var gXn, gYn int
-	for _, ii := range ei.ImageInfos {
-		for _, j := range ii.Joints {
-			if !j.FlagJoined || j.Confidence < legacyConfidenceCutoff {
-				continue
-			}
-			ac, ar, aok := resolve(j.Tile1)
-			bc, br, bok := resolve(j.Tile2)
-			if !aok || !bok {
-				continue
-			}
-			if ar == br && absDelta(ac, bc) == 1 {
-				g := min(ac, bc)
-				colSum[g] += float64(j.OverlapX)
-				colN[g]++
-				gXs += float64(j.OverlapX)
-				gXn++
-			}
-			if ac == bc && absDelta(ar, br) == 1 {
-				g := min(ar, br)
-				rowSum[g] += float64(j.OverlapY)
-				rowN[g]++
-				gYs += float64(j.OverlapY)
-				gYn++
-			}
+	for _, j := range ii.Joints {
+		if !j.FlagJoined || j.Confidence < legacyConfidenceCutoff {
+			continue
+		}
+		ac, ar, aok := resolve(j.Tile1)
+		bc, br, bok := resolve(j.Tile2)
+		if !aok || !bok {
+			continue
+		}
+		if ar == br && absDelta(ac, bc) == 1 {
+			g := min(ac, bc)
+			colSum[g] += float64(j.OverlapX)
+			colN[g]++
+			gXs += float64(j.OverlapX)
+			gXn++
+		}
+		if ac == bc && absDelta(ar, br) == 1 {
+			g := min(ar, br)
+			rowSum[g] += float64(j.OverlapY)
+			rowN[g]++
+			gYs += float64(j.OverlapY)
+			gYn++
 		}
 	}
 	gX := 0.0
@@ -322,7 +417,7 @@ func buildLegacyLayout(in StitchInput) *Layout {
 	if gYn > 0 {
 		gY = gYs / float64(gYn)
 	}
-	X := make([]int, cols)
+	X = make([]int, cols)
 	acc := 0.0
 	for col := 1; col < cols; col++ {
 		ov := gX
@@ -332,7 +427,7 @@ func buildLegacyLayout(in StitchInput) *Layout {
 		acc += float64(tw) - ov
 		X[col] = int(acc + 0.5)
 	}
-	Y := make([]int, rows)
+	Y = make([]int, rows)
 	acc = 0.0
 	for row := 1; row < rows; row++ {
 		ov := gY
@@ -342,26 +437,7 @@ func buildLegacyLayout(in StitchInput) *Layout {
 		acc += float64(th) - ov
 		Y[row] = int(acc + 0.5)
 	}
-	l := newLayout(cols, rows, tw, th)
-	maxX, maxY := 0, 0
-	for row := 0; row < rows; row++ {
-		for col := 0; col < cols; col++ {
-			l.origin[[2]int{col, row}] = TilePlacement{Col: col, Row: row, X: X[col], Y: Y[row]}
-		}
-	}
-	for col := 0; col < cols; col++ {
-		if X[col]+tw > maxX {
-			maxX = X[col] + tw
-		}
-	}
-	for row := 0; row < rows; row++ {
-		if Y[row]+th > maxY {
-			maxY = Y[row] + th
-		}
-	}
-	l.Width = maxX
-	l.Height = maxY
-	return l
+	return X, Y
 }
 
 // hasLiveJoint reports whether any joint is FlagJoined with confidence at or

--- a/formats/bif/stitch_legacy_test.go
+++ b/formats/bif/stitch_legacy_test.go
@@ -23,7 +23,8 @@ func legacyEI(cols, rows, ox, oy int) *bifxml.EncodeInfo {
 			}
 		}
 	}
-	return &bifxml.EncodeInfo{Ver: 2, ImageInfos: []bifxml.ImageInfo{ii}}
+	return &bifxml.EncodeInfo{Ver: 2, ImageInfos: []bifxml.ImageInfo{ii},
+		AoiOrigins: []bifxml.AoiOrigin{{Index: 0, OriginX: 0, OriginY: 0}}}
 }
 
 func TestBuildLegacyLayoutUniformOverlap(t *testing.T) {
@@ -74,6 +75,48 @@ func TestBuildLegacyLayoutDeadAndLowConfExcluded(t *testing.T) {
 	l2 := BuildLayout(StitchInput{Cols: 2, Rows: 1, TileW: 1000, TileH: 1000, EncodeInfo: ei2, Generation: GenerationLegacyIScan})
 	if x, _, _ := l2.TileOrigin(1, 0); x != 1000 {
 		t.Errorf("sub-cutoff joins must be excluded (X[1]=1000), got %d", x)
+	}
+}
+
+// TestBuildLegacyLayoutMultiAOI exercises the multi-AOI path (#67): two scanned
+// AOIs at separate origins plus one UNSCANNED AOI (skipped), each a 2×1 grid
+// with a RIGHT overlap 100 (tile 1000 → within-AOI advance 900). Each AOI's
+// tiles land at its own Pos-X; the unscanned region has no placement.
+func TestBuildLegacyLayoutMultiAOI(t *testing.T) {
+	mk := func(scanned bool, cols, posX, ox int) bifxml.ImageInfo {
+		ii := bifxml.ImageInfo{AOIScanned: scanned, NumCols: cols, NumRows: 1, PosX: posX, PosY: 0}
+		if scanned {
+			serp := func(c int) int { return imageToSerpentine(c, 0, cols, 1) + 1 }
+			for c := 0; c+1 < cols; c++ {
+				ii.Joints = append(ii.Joints, bifxml.TileJoint{FlagJoined: true, Direction: "RIGHT", Tile1: serp(c), Tile2: serp(c + 1), OverlapX: ox, Confidence: 100})
+			}
+		}
+		return ii
+	}
+	ei := &bifxml.EncodeInfo{Ver: 2,
+		ImageInfos: []bifxml.ImageInfo{mk(true, 2, 0, 100), mk(false, 3, 0, 0), mk(true, 2, 5000, 100)},
+		AoiOrigins: []bifxml.AoiOrigin{
+			{Index: 0, OriginX: 0, OriginY: 0},
+			{Index: 1, OriginX: 2048, OriginY: 0},    // unscanned → global cols 2..4, no tiles
+			{Index: 2, OriginX: 5120, OriginY: 0},    // start_col = 5 → global cols 5,6
+		},
+	}
+	l := BuildLayout(StitchInput{Cols: 7, Rows: 1, TileW: 1000, TileH: 1000, EncodeInfo: ei, Generation: GenerationLegacyIScan})
+	for _, c := range []struct {
+		col, wantX int
+		wantOK     bool
+	}{
+		{0, 0, true}, {1, 900, true}, // AOI0 at Pos-X 0
+		{5, 5000, true}, {6, 5900, true}, // AOI2 at Pos-X 5000
+		{2, 0, false}, // unscanned AOI region — no placement
+	} {
+		x, _, ok := l.TileOrigin(c.col, 0)
+		if ok != c.wantOK || (ok && x != c.wantX) {
+			t.Errorf("TileOrigin(%d,0) = (%d,%v), want (%d,%v)", c.col, x, ok, c.wantX, c.wantOK)
+		}
+	}
+	if l.Width != 6900 {
+		t.Errorf("Width = %d, want 6900 (AOI2 right edge 5900+1000)", l.Width)
 	}
 }
 

--- a/formats/bif/stitch_test.go
+++ b/formats/bif/stitch_test.go
@@ -31,7 +31,8 @@ func singleAOIEncodeInfo(cols, rows, ox, oy int) *bifxml.EncodeInfo {
 			}
 		}
 	}
-	return &bifxml.EncodeInfo{Ver: 2, ImageInfos: []bifxml.ImageInfo{ii}}
+	return &bifxml.EncodeInfo{Ver: 2, ImageInfos: []bifxml.ImageInfo{ii},
+		AoiOrigins: []bifxml.AoiOrigin{{Index: 0, OriginX: 0, OriginY: 0}}}
 }
 
 func TestBuildDPLayoutHorizontalOverlap(t *testing.T) {

--- a/tests/fixtures/OS-2.bif.json
+++ b/tests/fixtures/OS-2.bif.json
@@ -1,0 +1,490 @@
+{
+  "slide": "OS-2.bif",
+  "format": "bif",
+  "levels": [
+    {
+      "index": 0,
+      "size": [
+        114951,
+        76389
+      ],
+      "tile_size": [
+        1024,
+        1360
+      ],
+      "grid": [
+        125,
+        61
+      ],
+      "compression": "jpeg",
+      "mpp_um": 0.2325,
+      "pyramid_index": 0
+    },
+    {
+      "index": 1,
+      "size": [
+        57475,
+        38194
+      ],
+      "tile_size": [
+        1024,
+        1360
+      ],
+      "grid": [
+        63,
+        31
+      ],
+      "compression": "jpeg",
+      "mpp_um": 0.465,
+      "pyramid_index": 0
+    },
+    {
+      "index": 2,
+      "size": [
+        28737,
+        19097
+      ],
+      "tile_size": [
+        1024,
+        1360
+      ],
+      "grid": [
+        32,
+        16
+      ],
+      "compression": "jpeg",
+      "mpp_um": 0.93,
+      "pyramid_index": 0
+    },
+    {
+      "index": 3,
+      "size": [
+        14368,
+        9548
+      ],
+      "tile_size": [
+        1024,
+        1360
+      ],
+      "grid": [
+        16,
+        8
+      ],
+      "compression": "jpeg",
+      "mpp_um": 1.86,
+      "pyramid_index": 0
+    },
+    {
+      "index": 4,
+      "size": [
+        7184,
+        4774
+      ],
+      "tile_size": [
+        1024,
+        1360
+      ],
+      "grid": [
+        8,
+        4
+      ],
+      "compression": "jpeg",
+      "mpp_um": 3.72,
+      "pyramid_index": 0
+    },
+    {
+      "index": 5,
+      "size": [
+        3592,
+        2387
+      ],
+      "tile_size": [
+        1024,
+        1360
+      ],
+      "grid": [
+        4,
+        2
+      ],
+      "compression": "jpeg",
+      "mpp_um": 7.44,
+      "pyramid_index": 0
+    },
+    {
+      "index": 6,
+      "size": [
+        1796,
+        1193
+      ],
+      "tile_size": [
+        1024,
+        1360
+      ],
+      "grid": [
+        2,
+        1
+      ],
+      "compression": "jpeg",
+      "mpp_um": 14.88,
+      "pyramid_index": 0
+    },
+    {
+      "index": 7,
+      "size": [
+        898,
+        596
+      ],
+      "tile_size": [
+        1024,
+        1360
+      ],
+      "grid": [
+        1,
+        1
+      ],
+      "compression": "jpeg",
+      "mpp_um": 29.76,
+      "pyramid_index": 0
+    },
+    {
+      "index": 8,
+      "size": [
+        449,
+        298
+      ],
+      "tile_size": [
+        1024,
+        1360
+      ],
+      "grid": [
+        1,
+        1
+      ],
+      "compression": "jpeg",
+      "mpp_um": 59.52,
+      "pyramid_index": 0
+    },
+    {
+      "index": 9,
+      "size": [
+        224,
+        149
+      ],
+      "tile_size": [
+        1024,
+        1360
+      ],
+      "grid": [
+        1,
+        1
+      ],
+      "compression": "jpeg",
+      "mpp_um": 119.04,
+      "pyramid_index": 0
+    }
+  ],
+  "metadata": {
+    "magnification": 40,
+    "scanner_manufacturer": "Roche",
+    "scanner_serial": "BI10N0306"
+  },
+  "sampled_tiles": {
+    "0:0:0": {
+      "sha256": "f13642ae92b882f66ca0b03146adfbab65626486aef6bd1cfd8b8bd6bad04d7e",
+      "reason": "top-left corner"
+    },
+    "0:0:60": {
+      "sha256": "f13642ae92b882f66ca0b03146adfbab65626486aef6bd1cfd8b8bd6bad04d7e",
+      "reason": "bottom-left corner; OOB fill in y"
+    },
+    "0:124:0": {
+      "sha256": "e10d6c80a4e3571b97ee95f22676d59391d67b2bd4af811e61211d6d77b12d86",
+      "reason": "top-right corner; OOB fill in x"
+    },
+    "0:124:30": {
+      "sha256": "6865e4b804a21679f97d52b59b3056d0d65456c82c6bd3c37be5554e6fd63f3d",
+      "reason": "right-edge mid-column; OOB fill in x via 'right of image' callback"
+    },
+    "0:124:60": {
+      "sha256": "597cea7bdbc9a91b143ff2c35409f656fb52965dc8631fc298662ff3f86de759",
+      "reason": "bottom-right corner; OOB fill in both axes"
+    },
+    "0:1:30": {
+      "sha256": "ed38f2ad1d69e9f2cff2b04346c6e24e0d2f47f9db1827552de755d17e147d1b",
+      "reason": "near-left mid-row"
+    },
+    "0:31:15": {
+      "sha256": "3459b1ae174b65552498d94e499f3bb3e476ec281993c3136b816eefa32516b4",
+      "reason": "interior diagonal q1"
+    },
+    "0:62:1": {
+      "sha256": "738ddef77e14312eeaa221f795f97099ae8ac8c2527f9eb9891c642f9de18d6a",
+      "reason": "near-top mid-column"
+    },
+    "0:62:30": {
+      "sha256": "ae6cd39d29818d3e6d8b3f4df0c3cfd5765cd14f5ab8c88c5b498a0471dbbe88",
+      "reason": "interior diagonal q2 (center)"
+    },
+    "0:62:60": {
+      "sha256": "304044a2f22530660f820b5b53b3bd71838568411e31a4e822e9b7bf34129b13",
+      "reason": "bottom-edge mid-row; OOB fill in y via 'below image' callback"
+    },
+    "0:93:45": {
+      "sha256": "327759ee54e1c13643055b1769d53656e7019303fccf3d5d3184267132d13596",
+      "reason": "interior diagonal q3"
+    },
+    "1:0:0": {
+      "sha256": "f13642ae92b882f66ca0b03146adfbab65626486aef6bd1cfd8b8bd6bad04d7e",
+      "reason": "top-left corner"
+    },
+    "1:0:30": {
+      "sha256": "f13642ae92b882f66ca0b03146adfbab65626486aef6bd1cfd8b8bd6bad04d7e",
+      "reason": "bottom-left corner; OOB fill in y"
+    },
+    "1:15:7": {
+      "sha256": "f1334faa36208ac3014034ebfe8f987092ba460e8679de3db3bc88bf66cca027",
+      "reason": "interior diagonal q1"
+    },
+    "1:1:15": {
+      "sha256": "869bbae67816c40f770ca9bf3d3ec6760e4461a95627c164986dab834eb84fbd",
+      "reason": "near-left mid-row"
+    },
+    "1:31:1": {
+      "sha256": "4e6c2fccf9db133dc5e232d35711509834199954f80877168f801cc19099248a",
+      "reason": "near-top mid-column"
+    },
+    "1:31:15": {
+      "sha256": "92d8a7bb55545d1464536edb1c0a8418b6f7395d3441adff7d6b3e7edc97d48a",
+      "reason": "interior diagonal q2 (center)"
+    },
+    "1:31:30": {
+      "sha256": "1a3257715dfe2d277f3a46f9c3292f13befdfd6f3e39323c47fd895c9d84af71",
+      "reason": "bottom-edge mid-row; OOB fill in y via 'below image' callback"
+    },
+    "1:47:23": {
+      "sha256": "6dcc097dfb0df0238d9dabecd2f94ff3c80eadfeb58463d3ff0400fd1c831de3",
+      "reason": "interior diagonal q3"
+    },
+    "1:62:0": {
+      "sha256": "372936fff34e49f5e603e5c9f4677cec0273db56bb7bc3f8179b03cc0c0da8d8",
+      "reason": "top-right corner; OOB fill in x"
+    },
+    "1:62:15": {
+      "sha256": "59f8435130cfdbb4379c5f5ceca226652511b23cd9202224902139e42a81edc1",
+      "reason": "right-edge mid-column; OOB fill in x via 'right of image' callback"
+    },
+    "1:62:30": {
+      "sha256": "6886e63da57cfc0139f0f9f36bfe6becd675fc9d0320cf5486f988433aca34e8",
+      "reason": "bottom-right corner; OOB fill in both axes"
+    },
+    "2:0:0": {
+      "sha256": "f13642ae92b882f66ca0b03146adfbab65626486aef6bd1cfd8b8bd6bad04d7e",
+      "reason": "top-left corner"
+    },
+    "2:0:15": {
+      "sha256": "f13642ae92b882f66ca0b03146adfbab65626486aef6bd1cfd8b8bd6bad04d7e",
+      "reason": "bottom-left corner; OOB fill in y"
+    },
+    "2:16:1": {
+      "sha256": "8f84782cbc5841255504a73bcade48ead80dfbbd718c37968ce2fcb58bb25b15",
+      "reason": "near-top mid-column"
+    },
+    "2:16:15": {
+      "sha256": "ecc1c167a40dadf8cfe47286922b94a422575a1979e667c5fe8fc5742e48eefd",
+      "reason": "bottom-edge mid-row; OOB fill in y via 'below image' callback"
+    },
+    "2:16:8": {
+      "sha256": "11dbe98d6e9f5684026356b6d26f3c6ef70e709b736d853cf59a50175659955b",
+      "reason": "interior diagonal q2 (center)"
+    },
+    "2:1:8": {
+      "sha256": "245e13fc600a499ab84a00732290153118f77826e2afbb72b03d9e3c4730cdc7",
+      "reason": "near-left mid-row"
+    },
+    "2:24:12": {
+      "sha256": "78fc77546ddd1ed64a979c73fb246c36a7a5152500a62a35704074ee60aa07ff",
+      "reason": "interior diagonal q3"
+    },
+    "2:31:0": {
+      "sha256": "cf005a30976665fef5b194334dd06d8d885a2fa9d7c774c0b8c2e7aa1b5a85d9",
+      "reason": "top-right corner; OOB fill in x"
+    },
+    "2:31:15": {
+      "sha256": "569be7937bbf8d7ef706f7de7a4b6f299668d29a987dce1e4bc309adb8c23260",
+      "reason": "bottom-right corner; OOB fill in both axes"
+    },
+    "2:31:8": {
+      "sha256": "beb7fc86521aa9991c64637d607a7fa5598dc60de16e237b8475b0d37c53def6",
+      "reason": "right-edge mid-column; OOB fill in x via 'right of image' callback"
+    },
+    "2:8:4": {
+      "sha256": "967f65773abcc4ec06c7b80f0b2e6d0d815f7adfd6d061df6c96c5f321db9f65",
+      "reason": "interior diagonal q1"
+    },
+    "3:0:0": {
+      "sha256": "f13642ae92b882f66ca0b03146adfbab65626486aef6bd1cfd8b8bd6bad04d7e",
+      "reason": "top-left corner"
+    },
+    "3:0:7": {
+      "sha256": "f13642ae92b882f66ca0b03146adfbab65626486aef6bd1cfd8b8bd6bad04d7e",
+      "reason": "bottom-left corner; OOB fill in y"
+    },
+    "3:12:6": {
+      "sha256": "0ed6d532f7e9b2203d43a9b5c04232200fe8d2355f29bfade026b96de237a724",
+      "reason": "interior diagonal q3"
+    },
+    "3:15:0": {
+      "sha256": "9bf2aa14672999a8e818b58b27b47219b75d1ca764f5bb1827a3651458c9cc99",
+      "reason": "top-right corner; OOB fill in x"
+    },
+    "3:15:4": {
+      "sha256": "1ab62a139a2deba20a357d95de054c6a637d79e7fc75c0610cb77c2c62631cd7",
+      "reason": "right-edge mid-column; OOB fill in x via 'right of image' callback"
+    },
+    "3:15:7": {
+      "sha256": "41b638626ee78725baa922b1fbafada10aa24089a899134f2a6c469d214dfb0d",
+      "reason": "bottom-right corner; OOB fill in both axes"
+    },
+    "3:1:4": {
+      "sha256": "8ecb4728f5b88c942c901789b42a06593f989870e18930757cc6d8568f3d357e",
+      "reason": "near-left mid-row"
+    },
+    "3:4:2": {
+      "sha256": "005a8a5fbe37485afd2388b8b2c62f49cfbe1610c814a41104c0d374d63cc871",
+      "reason": "interior diagonal q1"
+    },
+    "3:8:1": {
+      "sha256": "2fb5d5325c02e8bd8fc3b7d20f52e7ce65558600a21301cbd771426a885e7110",
+      "reason": "near-top mid-column"
+    },
+    "3:8:4": {
+      "sha256": "01764afd11452cf92364d32a4fb39f44fbd32b4e44447c913f8f4cf1eb4b9d80",
+      "reason": "interior diagonal q2 (center)"
+    },
+    "3:8:7": {
+      "sha256": "eb0a09395509a64b43b60c4aff395c29596c7cb8fbfbee9792e991b722294b57",
+      "reason": "bottom-edge mid-row; OOB fill in y via 'below image' callback"
+    },
+    "4:0:0": {
+      "sha256": "f13642ae92b882f66ca0b03146adfbab65626486aef6bd1cfd8b8bd6bad04d7e",
+      "reason": "top-left corner"
+    },
+    "4:0:3": {
+      "sha256": "f13642ae92b882f66ca0b03146adfbab65626486aef6bd1cfd8b8bd6bad04d7e",
+      "reason": "bottom-left corner; OOB fill in y"
+    },
+    "4:1:2": {
+      "sha256": "c1644060598ad8b44eede55a41b0151d9a3efaac49e5984384f1dc3d0c1a96d5",
+      "reason": "near-left mid-row"
+    },
+    "4:2:1": {
+      "sha256": "0d19a3089b9a869ded373cc6bd2d9d4e9d93ac3654b934ad1aafa234258c2558",
+      "reason": "interior diagonal q1"
+    },
+    "4:4:1": {
+      "sha256": "9ab3b69147eff335a14d4c36042f1facd7ee6a6f04fbb57e9cae713ecd2d67c2",
+      "reason": "near-top mid-column"
+    },
+    "4:4:2": {
+      "sha256": "2f9808fac8c51976b73ff0653aa9c6e6a1d0cdf76a96a7a7ad4bcc8f912fd617",
+      "reason": "interior diagonal q2 (center)"
+    },
+    "4:4:3": {
+      "sha256": "998499698a94ef68bc44b42bc48a067aa47c2b9d170693226e3a9f94e56fe6a3",
+      "reason": "bottom-edge mid-row; OOB fill in y via 'below image' callback"
+    },
+    "4:6:3": {
+      "sha256": "eebe41d3208bd04f6873b2b671853dc9d120eab94f7c6a85b17e0788de287dff",
+      "reason": "interior diagonal q3"
+    },
+    "4:7:0": {
+      "sha256": "f92a932347d4c3748460b94ad3589a303158145c4604da5573660efd566fc689",
+      "reason": "top-right corner; OOB fill in x"
+    },
+    "4:7:2": {
+      "sha256": "793e0032a8bfcc099b82b39b31cf273effda02a2410a8c241f96a51b12b3aaee",
+      "reason": "right-edge mid-column; OOB fill in x via 'right of image' callback"
+    },
+    "4:7:3": {
+      "sha256": "8d32544314f9e6b81ad72885d0a5fc64d4d79fcb28418c9b40e6c55fceb47877",
+      "reason": "bottom-right corner; OOB fill in both axes"
+    },
+    "5:0:0": {
+      "sha256": "a17536428a03777f08298237b714184fa99977a735012cbcc2436ccd10c67044",
+      "reason": "top-left corner"
+    },
+    "5:0:1": {
+      "sha256": "a5603ffc5c6ff4155fded3a1ae40013e0b27a82e8ffc9f13e7907753d705e938",
+      "reason": "bottom-left corner; OOB fill in y"
+    },
+    "5:1:0": {
+      "sha256": "ffabf5f421197a0bad5d723a77477cd814a0daca5fe7118d3f65d49a75ea2eda",
+      "reason": "interior diagonal q1"
+    },
+    "5:1:1": {
+      "sha256": "a84cf63d4a95778c70bcffc058c0242a795c4bad3b45e4edf9ba78614ff134d0",
+      "reason": "near-left mid-row"
+    },
+    "5:2:1": {
+      "sha256": "7925f03cbc151d94c15a96c1b746a823b69e227cbeaecceec9d02c6eb07266de",
+      "reason": "interior diagonal q2 (center)"
+    },
+    "5:3:0": {
+      "sha256": "da9b8096076f37bdb1cf31f62277d661db635b7ebe85edb8f9b7f0f87f0c87e4",
+      "reason": "top-right corner; OOB fill in x"
+    },
+    "5:3:1": {
+      "sha256": "2495d18fbf362cd5e38495448ba763c87e8b5f2801b8b960afc9a7f2e6d2f246",
+      "reason": "bottom-right corner; OOB fill in both axes"
+    },
+    "6:0:0": {
+      "sha256": "beb52a9e6983e1ef0d3b38c041b071ac231ab9802e626859c054cbe1b07fbc92",
+      "reason": "top-left corner"
+    },
+    "6:1:0": {
+      "sha256": "6d8a194411b8e9ed224ed9688a5b9d29ba4d55664749ae8a745d9027f8f6f3f6",
+      "reason": "top-right corner; OOB fill in x"
+    },
+    "7:0:0": {
+      "sha256": "72b565307d50c41b4b9c01a4badbee511a50605d08b9a5ea84bba151b0bd68c6",
+      "reason": "top-left corner"
+    },
+    "8:0:0": {
+      "sha256": "68d938e0191b94521ef273b7e985729b86e1fa181dbc688c519e1e06a9a654b9",
+      "reason": "top-left corner"
+    },
+    "9:0:0": {
+      "sha256": "e39c7f26a33fc72659a6110da15a35d012192eb5a442e8bf36dabb2fee689bc1",
+      "reason": "top-left corner"
+    }
+  },
+  "associated": [
+    {
+      "type": "overview",
+      "size": [
+        1008,
+        3008
+      ],
+      "compression": "jpeg",
+      "sha256": "f9ab00795141ffe34382c6b7ed63bc95726795163f0ce1fab606a08646aab3f9"
+    },
+    {
+      "type": "label",
+      "size": [
+        1008,
+        1002
+      ],
+      "compression": "none",
+      "sha256": "54c66253fd639956261e8048e479629fd4a16f409bb26ff312cfa61b3e39fa91"
+    },
+    {
+      "type": "thumbnail",
+      "size": [
+        1024,
+        688
+      ],
+      "compression": "jpeg",
+      "sha256": "0acb67d24a42b0a38eb1de048a2eb2192202e3b0dc84e9ccf31047508bbd40ce"
+    }
+  ]
+}

--- a/tests/generate_test.go
+++ b/tests/generate_test.go
@@ -34,7 +34,7 @@ func sampledByDefault(slide string) bool {
 		return true
 	// BIF fixtures: Ventana-1 is 227 MB and OS-1 is 3.6 GB —
 	// both qualify under the >100 MB sampled-by-default policy.
-	case "Ventana-1.bif", "OS-1.bif":
+	case "Ventana-1.bif", "OS-1.bif", "OS-2.bif":
 		return true
 	// IFE: cervix_2x_jpeg is 2.1 GB; sample-only.
 	case "cervix_2x_jpeg.iris":

--- a/tests/integration_test.go
+++ b/tests/integration_test.go
@@ -54,6 +54,11 @@ var slideCandidates = []string{
 	"CMU-1-Small-Region.ome.tiff",
 	"Ventana-1.bif",
 	"OS-1.bif",
+	// OS-2.bif (v0.58): multi-AOI legacy iScan (#67) — three AoiOrigins, two
+	// scanned tissue areas at separate Pos-X/Pos-Y anchors. PHI/local-only
+	// fixture (gitignored); the committed OS-2.bif.json snapshot is SHA-only, so
+	// CI skips it cleanly when the slide is absent.
+	"OS-2.bif",
 	"cervix_2x_jpeg.iris",
 	// Generic TIFF (v0.10): catch-all reader for tiled pyramidal
 	// TIFFs without vendor metadata. CMU-1.tiff is the

--- a/tests/parity/bif_geometry_test.go
+++ b/tests/parity/bif_geometry_test.go
@@ -100,6 +100,33 @@ var bifFixtures = []bifFixture{
 		overviewWxH:   [2]int{1008, 3008},
 		hasThumbnail:  true,
 	},
+	{
+		// OS-2 is a MULTI-AOI legacy iScan slide (#67): three AoiOrigins, two
+		// scanned tissue areas placed at their own Pos-X/Pos-Y anchors (Y measured
+		// from each AOI's bottom → Y-flipped during layout). L0 Size is the union
+		// hull across all scanned AOIs (114951×76389); reduced levels floor-halve.
+		// Grid stays the raw frame grid (125×61). PHI/local-only fixture — skips in
+		// CI. See buildLegacyLayout multi-AOI path + docs/formats/bif.md.
+		filename: "OS-2.bif",
+		levels: []bifLevelExpect{
+			{W: 114951, H: 76389, TileW: 1024, TileH: 1360, GridW: 125, GridH: 61, OverlapX: 31, OverlapY: 31},
+			{W: 57475, H: 38194, TileW: 1024, TileH: 1360, GridW: 63, GridH: 31},
+			{W: 28737, H: 19097, TileW: 1024, TileH: 1360, GridW: 32, GridH: 16},
+			{W: 14368, H: 9548, TileW: 1024, TileH: 1360, GridW: 16, GridH: 8},
+			{W: 7184, H: 4774, TileW: 1024, TileH: 1360, GridW: 8, GridH: 4},
+			{W: 3592, H: 2387, TileW: 1024, TileH: 1360, GridW: 4, GridH: 2},
+			{W: 1796, H: 1193, TileW: 1024, TileH: 1360, GridW: 2, GridH: 1},
+			{W: 898, H: 596, TileW: 1024, TileH: 1360, GridW: 1, GridH: 1},
+			{W: 449, H: 298, TileW: 1024, TileH: 1360, GridW: 1, GridH: 1},
+			{W: 224, H: 149, TileW: 1024, TileH: 1360, GridW: 1, GridH: 1},
+		},
+		scanRes:       0.2325,
+		generation:    "legacy-iscan",
+		hasICC:        false,
+		encodeInfoVer: 2,
+		overviewWxH:   [2]int{1008, 3008},
+		hasThumbnail:  true,
+	},
 }
 
 func TestBIFGeometry(t *testing.T) {


### PR DESCRIPTION
## Summary

Legacy iScan BIF slides may carry several **Areas of Interest** (AOIs) — separate scanned tissue regions, each a sub-grid of the global tile grid placed at its own slide origin. `OS-2.bif` has three `AoiOrigin` nodes (two scanned, one unscanned). `buildLegacyLayout` previously stitched the whole frame grid as a single AOI, overlaying the disjoint regions and leaving a visible seam through the large AOI on zoom (openscope: "very broken once you start to zoom in").

Following openslide's `openslide-vendor-ventana.c` area model (clean-room — read as a black-box oracle, not translated):

- pair `ImageInfo[i]` with `AoiOrigin[i]` by document order
- skip `AOIScanned=false` AOIs
- place each scanned AOI's local `NumCols×NumRows` grid at its own `(Pos-X, Pos-Y)` anchor; start cell = `Origin / TileSize`
- **Pos-Y is measured from the AOI bottom** → Y-flip to image space (`top − Pos-Y − height`)
- within each AOI, reuse the per-gap-average overlap model (#63), extracted into `localOffsets` and run over the AOI's local grid
- union hull across scanned AOIs, normalized to `(0,0)`

**Single-AOI slides (OS-1) are the degenerate case and remain byte-identical.** OS-2 L0 now reports the union hull `114951×76389` with the inter-AOI seam removed; reduced levels floor-halve.

Per-tile raw/decoded bytes and `Grid` are unchanged (raw frame addressing). Only the stitched placement (`Level.Size`, `ReadRegion`/`ReadRegionScaled`/`ScaledStrips`/`StitchedTile`) changes, and only for multi-AOI legacy slides. The other 10 formats and DP-generation BIF are untouched.

Closes #67.

## Test Plan

- [x] `TestBuildLegacyLayoutMultiAOI` — synthetic CI-safe gate: two scanned AOIs at separate origins + one unscanned (returns `ok=false`), placements + hull width verified
- [x] Single-AOI unit tests (`TestBuildLegacyLayoutUniformOverlap`, …) unchanged and green (OS-1 path byte-identical)
- [x] `TestBIFGeometry/OS-2.bif` — new geometry pin (union hull + floor-halve reduced levels + 3 AOI origins)
- [x] `TestSlideParity/OS-2.bif` — new SHA snapshot (`tests/fixtures/OS-2.bif.json`)
- [x] Full `go test ./...` green (cgo); `go vet ./...`; nocgo build green
- [x] `go test ./formats/bif/ -race` green
- [x] Render-validated locally: OS-1 unchanged, OS-2 big-AOI seam gone, small AOI placed separately per origin

> OS-2.bif is a **PHI/local-only** fixture (gitignored). The committed `OS-2.bif.json` and geometry pin are SHA/geometry-only and skip cleanly in CI when the slide is absent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)