### PR TITLE
docs: strike JP2K encode from the roadmap (reader-only)

### DIFF
--- a/docs/deferred.md
+++ b/docs/deferred.md
@@ -26,7 +26,7 @@ TIFF** (R6, [#2](https://github.com/WSILabs/opentile-go/issues/2)) and
 **Sakura SVSlide** (R15, [#3](https://github.com/WSILabs/opentile-go/issues/3))
 are parked behind GH issues — 3DHistech TIFF is a niche single-file
 conversion target we've never encountered in the wild; Sakura is rare
-enough to follow the same trigger-driven deferral as R4/R9. The
+enough to follow the same trigger-driven deferral as R4. The
 multi-file **native MRXS** (MIRAX) source format — the main unbuilt
 WSI format and a larger clean-room effort — is tracked separately at
 [#100](https://github.com/WSILabs/opentile-go/issues/100).
@@ -38,9 +38,12 @@ we read it for understanding rather than direct port; correctness bar
 shifts from byte-parity to pixel-equivalence with openslide on decoded
 tiles.
 
-R4 / R9 (SVS corrupt-edge reconstruct + JP2K decode/encode) remain
-parked at [#1](https://github.com/wsilabs/opentile-go/issues/1) until a
-real slide motivates the work.
+R4 (SVS corrupt-edge reconstruct) remains parked at
+[#1](https://github.com/WSILabs/opentile-go/issues/1) until a real slide
+motivates the work. JP2K *decode* shipped (OpenJPEG; RGB/YCbCr fix
+v0.45.1, [#53](https://github.com/WSILabs/opentile-go/issues/53)); JP2K
+*encode* is **not** an opentile-go item — it is writer-side work
+(wsitools), out of a reader's scope, and is struck from this roadmap.
 
 | ID | Feature | Target | Status |
 |----|---------|--------|--------|
@@ -52,7 +55,7 @@ real slide motivates the work.
 | R6 | 3DHistech TIFF | parked | parked behind [#2](https://github.com/WSILabs/opentile-go/issues/2). Single-file conversion target produced by 3DHistech software; rare in practice. Trigger to take it on is a real slide. Upstream opentile has a ~200 LOC reader; cheap to revive if motivated. (The multi-file *native* MRXS source format is a separate, larger effort — tracked at [#100](https://github.com/WSILabs/opentile-go/issues/100).) |
 | R7 | OME TIFF | v0.6 | ✅ landed. Closes the upstream-opentile format set; SubIFD-based pyramid + multi-image deviation + dual-reference parity (opentile-py + tifffile). |
 | R8 | BigTIFF support | v0.2 | ✅ landed (Batch 1) |
-| R9 | JPEG 2000 decode/encode (currently passes through native tiles; decode matters for associated-image re-encoding and corrupt-tile reconstruct) | v0.5+ | deferred — see [#1](https://github.com/wsilabs/opentile-go/issues/1). Only consumer is R4; deferred together. Native JP2K tile passthrough (the v0.1+ behaviour) continues to work — decode is only needed for the reconstruct chain. |
+| R9 | JPEG 2000 decode | ✅ landed | JP2K **decode** is supported (OpenJPEG via `decoder/jpeg2000`; `JP2K-33003-1.svs` reads in CI; RGB/YCbCr codestream fix v0.45.1 [#53](https://github.com/WSILabs/opentile-go/issues/53)). Native JP2K tile passthrough (the v0.1+ behaviour) is unaffected. **JP2K encode is struck** — opentile-go is a reader; tile encoding is writer-side (wsitools), out of scope, not a roadmap item. |
 | R10 | Remote I/O backends (S3, HTTP range, fsspec equivalents) | out-of-scope; consumers supply `io.ReaderAt` | permanent |
 | R11 | Python parity oracle under `//go:build parity` | v0.2 | ✅ landed (Task 25-26, Batch 7) |
 | R12 | CLI wrapper | out-of-scope for v1 | permanent |
@@ -2535,8 +2538,7 @@ decisions, not deferred work.
 | **L20** — DP 600 unverified | BIF | Fixture-driven | v0.7 | First DP 600 fixture surfaces — tracked at [#99](https://github.com/WSILabs/opentile-go/issues/99) |
 | **L23** — IFE cross-tool parity vs `tile_server_iris` | IFE | Trigger-driven | v0.8 | First downstream divergence story |
 | **L25** — IFE ANNOTATIONS block parsing | IFE | Fixture-driven | v0.8 | First annotated IFE fixture surfaces |
-| **R4** — SVS corrupt-edge reconstruct | SVS | Trigger-driven | parked at [#1](https://github.com/wsilabs/opentile-go/issues/1) | First corrupt-edge SVS in our slate |
-| **R9** — JPEG 2000 ~~decode~~/encode | SVS | Mostly resolved | parked at [#1](https://github.com/wsilabs/opentile-go/issues/1) | JP2K **decode shipped** (OpenJPEG; RGB/YCbCr fix v0.45.1 [#53](https://github.com/WSILabs/opentile-go/issues/53)). JP2K *encode* is out of opentile's reader scope (writer-side / wsitools). |
+| **R4** — SVS corrupt-edge reconstruct | SVS | Trigger-driven | parked at [#1](https://github.com/WSILabs/opentile-go/issues/1) | First corrupt-edge SVS in our slate |
 | **R6** — 3DHistech TIFF support | (new) | Trigger-driven | parked at [#2](https://github.com/WSILabs/opentile-go/issues/2) | First 3DHistech TIFF in the wild |
 | **MRXS (MIRAX) native reader** | (new) | Trigger-driven; main unbuilt format | tracked at [#100](https://github.com/WSILabs/opentile-go/issues/100) | Owner sign-off + a real `.mrxs` slide. Multi-file INI/binary-index container; clean-room from `openslide-vendor-mirax.c`; the BIF `regionLayout` compositing infra may apply if tiles overlap. |
 | **R15** — Sakura SVSlide support | (new) | Trigger-driven | parked at [#3](https://github.com/wsilabs/opentile-go/issues/3) | First SVSlide in the wild |

--- a/docs/formats/svs.md
+++ b/docs/formats/svs.md
@@ -64,7 +64,7 @@ namespace ensures parsing doesn't break for unrecognized writers.
 | Capability | Status | Why |
 |---|---|---|
 | Corrupt-edge tile reconstruct | ❌ deferred → [#1](https://github.com/wsilabs/opentile-go/issues/1) | None of our local SVS fixtures exhibits the bug. Upstream's reconstruct chain is ~12 tasks of new cgo + a Pillow BILINEAR port; speculation without a real triggering slide. Tile() returns `ErrCorruptTile` for `TileByteCounts[idx] == 0`. |
-| JPEG 2000 decode/encode | ❌ deferred → [#1](https://github.com/wsilabs/opentile-go/issues/1) | Only consumer is the corrupt-edge reconstruct chain. Native JP2K passthrough (the v0.1+ behaviour) is unaffected. |
+| JPEG 2000 decode | ✅ supported | OpenJPEG via `decoder/jpeg2000`; `JP2K-33003-1.svs` reads in CI (RGB/YCbCr codestream fix v0.45.1, [#53](https://github.com/WSILabs/opentile-go/issues/53)). Native JP2K tile passthrough (the v0.1+ behaviour) is also unaffected. JP2K *encode* is out of scope — opentile-go is a reader; tile encoding is writer-side (wsitools). |
 
 ## Parity
 


### PR DESCRIPTION
## Summary

Per maintainer call: JPEG 2000 **encode** is never an opentile-go deliverable — opentile-go is a *reader*; tile encoding is writer-side (wsitools). JP2K **decode** already shipped (OpenJPEG; RGB/YCbCr codestream fix v0.45.1, #53). This strikes JP2K-encode from the active TODO surfaces:

- **deferred.md §1 prose** — R4-only deferral; record JP2K decode shipped + encode struck/out-of-scope.
- **deferred.md §1 table** — `R9 → "JPEG 2000 decode | ✅ landed"`; encode struck.
- **deferred.md §11 backlog** — removed the R9 row (no longer a backlog item).
- **docs/formats/svs.md** — JP2K decode ✅ supported; encode out of scope.

Historical "Retired in v0.17/18/19" deferred-forward snapshots (which list `R4/R6/R9` as the then-current set) are left **verbatim** as point-in-time records, consistent with the project's convention for retired sections. GitHub #1 is already scoped to R4 (title + clarifying comment from the prior audit).

Doc-only; no code changes.

## Test Plan
- [x] Doc-only; markdown tables verified (column counts intact)
- [x] No active TODO surface still lists JP2K encode as pending

🤖 Generated with [Claude Code](https://claude.com/claude-code)