### PR TITLE
fix(bif): OverlapMode=OverlapStitched on stitched levels (v0.60.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,23 @@ The single source of truth for "what was deferred and why" is
 front-page summary; the deferred file has the full reasoning,
 upstream references, and retirement audit per milestone.
 
+## [0.60.1] — 2026-06-27
+
+### Fixed
+
+- **BIF `Level.OverlapMode` was `OverlapNone` on stitched levels.** v0.60.0 added
+  the `OverlapMode` field and wired DZI/SZI to set it, but the BIF reader was not
+  updated — it set only the (correct) `Overlapping` bool, leaving `OverlapMode` at
+  its zero value. So a stitched BIF level reported `Overlapping=true` but
+  `OverlapMode=OverlapNone`, violating the documented invariant
+  `Overlapping == (OverlapMode != OverlapNone)` and mis-reporting BIF as
+  non-overlapping via the new enum. BIF now derives both fields from one source:
+  overlapping levels report `OverlapStitched`, non-overlapping report
+  `OverlapNone`. The `Overlapping` bool value is unchanged (it was already
+  correct), so consumers gating on `!Overlapping` are unaffected; only the
+  `OverlapMode` enum value is corrected. New `TestOverlapModeInvariant`
+  (cross-format) and a BIF-specific `OverlapStitched` assertion guard it.
+
 ## [0.60.0] — 2026-06-26
 
 DZI/SZI `Overlap > 0` support — clean composited output, new `OverlapMode` /

--- a/formats/bif/bif.go
+++ b/formats/bif/bif.go
@@ -123,6 +123,13 @@ func openFromTIFFFile(file *tiff.File, cfg *format.Config) (format.Reader, error
 			l.overlapping = true
 		}
 		levelImpls = append(levelImpls, l)
+		// BIF overlapping levels are stitched (compacted hull; Grid does not tile
+		// Size). Derive both the enum and the bool from one source so the
+		// invariant Overlapping == (OverlapMode != OverlapNone) holds.
+		overlapMode := opentile.OverlapNone
+		if l.overlapping {
+			overlapMode = opentile.OverlapStitched
+		}
 		valueLevels = append(valueLevels, opentile.Level{
 			Index:        l.index,
 			PyramidIndex: l.pyrIndex,
@@ -132,7 +139,8 @@ func openFromTIFFFile(file *tiff.File, cfg *format.Config) (format.Reader, error
 			Compression:  l.compression,
 			MPP:          l.mpp,
 			TileOverlap:  l.tileOverlap,
-			Overlapping:  l.overlapping,
+			OverlapMode:  overlapMode,
+			Overlapping:  overlapMode != opentile.OverlapNone,
 			FocalPlane:   0,
 			// l0Width is the level-0 STITCHED width (the compacted hull, #60);
 			// lower levels report their own IFD extent (pre-stitched, no joints

--- a/tests/integration_test.go
+++ b/tests/integration_test.go
@@ -138,6 +138,44 @@ func resolveSlide(dir, name string) (string, bool) {
 	return "", false
 }
 
+// TestOverlapModeInvariant asserts the public-API invariant
+// Overlapping == (OverlapMode != OverlapNone) holds for every level of every
+// present fixture, across all formats. Guards the v0.60.0 OverlapMode addition
+// against a reader setting one field but not the other — the v0.60.0 BIF gap
+// (fixed in v0.60.1) where stitched levels reported Overlapping=true but
+// OverlapMode=OverlapNone. Runs on whatever fixtures are present (BIF Ventana-1
+// is in CI, so the BIF case is covered there).
+func TestOverlapModeInvariant(t *testing.T) {
+	dir := tests.TestdataDir()
+	if dir == "" {
+		t.Skip("OPENTILE_TESTDIR not set")
+	}
+	any := false
+	for _, name := range slideCandidates {
+		slide, ok := resolveSlide(dir, name)
+		if !ok {
+			continue
+		}
+		any = true
+		t.Run(name, func(t *testing.T) {
+			s, err := opentile.OpenFile(slide)
+			if err != nil {
+				t.Fatalf("OpenFile: %v", err)
+			}
+			defer s.Close()
+			for _, l := range s.Levels() {
+				if l.Overlapping != (l.OverlapMode != opentile.OverlapNone) {
+					t.Errorf("level %d: Overlapping=%v but OverlapMode=%v — invariant Overlapping==(OverlapMode!=OverlapNone) violated",
+						l.Index, l.Overlapping, l.OverlapMode)
+				}
+			}
+		})
+	}
+	if !any {
+		t.Skip("no fixtures present")
+	}
+}
+
 // TestSlideParity reads each candidate slide, walks every (level, x, y), and
 // compares against the committed fixture. Slides without a fixture or without
 // an on-disk file are skipped — this lets developers iterate on a subset of

--- a/tests/parity/bif_geometry_test.go
+++ b/tests/parity/bif_geometry_test.go
@@ -167,6 +167,16 @@ func TestBIFGeometry(t *testing.T) {
 				if got := lvl.TileOverlap; got.X != want.OverlapX || got.Y != want.OverlapY {
 					t.Errorf("L%d TileOverlap: got %v, want (%d,%d)", i, got, want.OverlapX, want.OverlapY)
 				}
+				// OverlapMode must agree with Overlapping (the v0.60.1 fix): a
+				// stitched/overlapping BIF level reports OverlapStitched, a
+				// non-overlapping one reports OverlapNone.
+				wantMode := opentile.OverlapNone
+				if lvl.Overlapping {
+					wantMode = opentile.OverlapStitched
+				}
+				if lvl.OverlapMode != wantMode {
+					t.Errorf("L%d OverlapMode: got %v, want %v (Overlapping=%v)", i, lvl.OverlapMode, wantMode, lvl.Overlapping)
+				}
 				// Per-level dimensions in the table above are the
 				// strict pin. We don't re-check the multiplicative
 				// downscale factor here: legacy iScan slides


### PR DESCRIPTION
## Summary

Patch fixing a self-inconsistency introduced by v0.60.0. The DZI/SZI Overlap>0 work added `Level.OverlapMode` and wired DZI/SZI to set it, but **the BIF reader was never updated** — it sets only the (correct) `Overlapping` bool and left `OverlapMode` at its zero value.

Result: a **stitched BIF level reported `Overlapping=true` but `OverlapMode=OverlapNone`**, which:
- violates the documented invariant `Overlapping == (OverlapMode != OverlapNone)` (image.go field docs);
- mis-reports BIF as non-overlapping (`OverlapNone`) when it should be `OverlapStitched`.

Confirmed across formats:

| Format | `Overlapping` | `OverlapMode` (before → after) |
|---|---|---|
| BIF (stitched levels) | `true` | `none` ❌ → **`stitched`** ✅ |
| DZI/SZI overlap>0 | `true` | `bordered` (already correct) |
| DZI/SZI overlap=0 + 9 other formats | `false` | `none` (already correct) |

## Fix

`formats/bif/bif.go` now derives both fields from one source — overlapping levels → `OverlapStitched`, else `OverlapNone` — so they can't drift. **The `Overlapping` bool value is unchanged** (it was already correct), so `!Overlapping` consumers (wsitools/openscope) are unaffected; only the `OverlapMode` enum is corrected.

## Test plan

- [x] New **`TestOverlapModeInvariant`** (cross-format) — walks every present fixture and asserts `Overlapping == (OverlapMode != OverlapNone)` per level; passes for all 12 formats (BIF Ventana-1 is in CI, so the BIF case is covered there). This is the gate that would have caught the original bug.
- [x] BIF-specific assertion in `TestBIFGeometry`: overlapping levels report `OverlapStitched`.
- [x] Full `./...` green; `go vet`; nocgo build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)