### PR TITLE
fix(jpegxl): decode was completely broken (invalid event subscription)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,23 @@ The single source of truth for "what was deferred and why" is
 front-page summary; the deferred file has the full reasoning,
 upstream references, and retirement audit per milestone.
 
+## [0.60.2] — 2026-07-07
+
+### Fixed
+
+- **JPEG-XL decode never worked.** The `decoder/jpegxl` decode path subscribed to
+  `JXL_DEC_NEED_IMAGE_OUT_BUFFER` via `JxlDecoderSubscribeEvents`. That constant
+  is a *return-only* status (value `5`), not a subscribable bit-flag event (those
+  are the power-of-two `JXL_DEC_BASIC_INFO` / `JXL_DEC_FULL_IMAGE`); passing it
+  made libjxl reject the entire subscription (`JXL_DEC_ERROR`), so every decode
+  failed with "corrupt input data" — even for valid tiles that `djxl` decodes.
+  It went unnoticed because the package had no decode test (only registration +
+  header-`Inspect`, which subscribes to `BASIC_INFO` alone and worked). Now
+  subscribes to `JXL_DEC_BASIC_INFO | JXL_DEC_FULL_IMAGE` only; `Decode` /
+  `DecodedTile` / `ReadRegion` work for JPEG-XL tiles (generic-TIFF Compression
+  50002). Added a real end-to-end decode gate (`TestDecodeSampleTile`) that
+  decodes a committed 240×240 `.jxl` tile and asserts real pixels come back.
+
 ## [0.60.1] — 2026-06-27
 
 ### Fixed

--- a/decoder/jpegxl/jxl_cgo.go
+++ b/decoder/jpegxl/jxl_cgo.go
@@ -30,8 +30,14 @@ static int wsi_jxl_decode(
     JxlDecoder *dec = JxlDecoderCreate(NULL);
     if (!dec) return -1;
 
+    // Subscribe ONLY to the bit-flag events (BASIC_INFO, FULL_IMAGE).
+    // JXL_DEC_NEED_IMAGE_OUT_BUFFER is a RETURN-ONLY status (value 5, not a
+    // power-of-two subscribable flag); passing it to JxlDecoderSubscribeEvents
+    // makes libjxl reject the whole mask (JXL_DEC_ERROR), which previously broke
+    // every decode. ProcessInput still emits NEED_IMAGE_OUT_BUFFER on its own;
+    // it is handled in the loop below.
     if (JxlDecoderSubscribeEvents(dec,
-            JXL_DEC_BASIC_INFO | JXL_DEC_NEED_IMAGE_OUT_BUFFER | JXL_DEC_FULL_IMAGE)
+            JXL_DEC_BASIC_INFO | JXL_DEC_FULL_IMAGE)
             != JXL_DEC_SUCCESS) {
         JxlDecoderDestroy(dec);
         return -1;

--- a/decoder/jpegxl/jxl_test.go
+++ b/decoder/jpegxl/jxl_test.go
@@ -3,6 +3,7 @@
 package jpegxl
 
 import (
+	"os"
 	"testing"
 
 	"github.com/wsilabs/opentile-go/decoder"
@@ -18,8 +19,69 @@ func TestRegistered(t *testing.T) {
 	}
 }
 
-// End-to-end Decode validation: encode a known image via the wsitools
-// encoder, decode via this package, assert pixel-level closeness.
-// Detailed test added when encoder + decoder are both available; defer
-// to wsitools v0.9.0 cross-checks if fixtures aren't readily available
-// in this repo.
+// TestDecodeSampleTile is the end-to-end decode gate: decode a real 240×240
+// JPEG-XL tile and confirm actual image data comes back. Guards the bug where
+// the decoder subscribed to JXL_DEC_NEED_IMAGE_OUT_BUFFER (a return-only status,
+// not a subscribable flag), which made libjxl reject the event subscription and
+// every decode fail with "corrupt input data".
+func TestDecodeSampleTile(t *testing.T) {
+	b, err := os.ReadFile("testdata/sample_tile.jxl")
+	if err != nil {
+		t.Fatal(err)
+	}
+	f, ok := decoder.Get("jpegxl")
+	if !ok {
+		t.Fatal("jpegxl decoder not registered")
+	}
+	d := f.New()
+	defer d.Close()
+
+	img, err := d.Decode(b, decoder.DecodeOptions{})
+	if err != nil {
+		t.Fatalf("Decode(RGB): %v", err)
+	}
+	if img.Width != 240 || img.Height != 240 {
+		t.Errorf("dims = %dx%d, want 240x240", img.Width, img.Height)
+	}
+	if img.Format != decoder.PixelFormatRGB {
+		t.Errorf("format = %v, want RGB", img.Format)
+	}
+	if !hasVariation(img) {
+		t.Error("decoded pixels are uniform — decode did not produce real image data")
+	}
+
+	// RGBA path.
+	rgba, err := d.Decode(b, decoder.DecodeOptions{Format: decoder.PixelFormatRGBA})
+	if err != nil {
+		t.Fatalf("Decode(RGBA): %v", err)
+	}
+	if rgba.Width != 240 || rgba.Height != 240 || rgba.Format != decoder.PixelFormatRGBA {
+		t.Errorf("RGBA decode = %dx%d fmt=%v, want 240x240 RGBA", rgba.Width, rgba.Height, rgba.Format)
+	}
+
+	// Decode-into a caller-provided destination of the right size.
+	dst := decoder.NewImageFormat(240, 240, decoder.PixelFormatRGB)
+	if _, err := d.Decode(b, decoder.DecodeOptions{Dst: dst}); err != nil {
+		t.Fatalf("Decode(Dst): %v", err)
+	}
+}
+
+// hasVariation reports whether any pixel differs from the top-left pixel — a
+// cheap proof that a real (non-flat) image was decoded. Stride-aware.
+func hasVariation(img *decoder.Image) bool {
+	bpp := 3
+	if img.Format == decoder.PixelFormatRGBA {
+		bpp = 4
+	}
+	r0, g0, b0 := img.Pix[0], img.Pix[1], img.Pix[2]
+	for y := 0; y < img.Height; y++ {
+		row := img.Pix[y*img.Stride:]
+		for x := 0; x < img.Width; x++ {
+			i := x * bpp
+			if row[i] != r0 || row[i+1] != g0 || row[i+2] != b0 {
+				return true
+			}
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## Summary

JPEG-XL **decode has never worked**. The decoder is registered and reads headers (`Inspect`), but every full decode failed with `decoder: corrupt input data` — on the test sample *and* on real `jxl-out.tiff` generic-TIFF slides — even though `djxl` (the same libjxl 0.11.2) decodes them fine.

## Root cause

`decoder/jpegxl/jxl_cgo.go` subscribed to `JXL_DEC_NEED_IMAGE_OUT_BUFFER` in `JxlDecoderSubscribeEvents`. That constant is a **return-only status** (value `5`) that `JxlDecoderProcessInput` emits — **not** a subscribable bit-flag event. Subscribable events are the power-of-two ones (`JXL_DEC_BASIC_INFO=0x40`, `JXL_DEC_FULL_IMAGE=0x1000`). Passing `5` makes libjxl reject the *entire* subscription (`JxlDecoderSubscribeEvents` returns `JXL_DEC_ERROR`); `ProcessInput` then returns `JXL_DEC_SUCCESS` immediately with no output buffer, and the loop falls into the "corrupt input data" fail path.

Isolated empirically:
```
BASIC_INFO alone            rc=0
FULL_IMAGE alone            rc=0
NEED_IMAGE_OUT_BUFFER alone rc=1   ← rejected (value 5, not a subscribable flag)
BASIC|FULL|NEEDBUF          rc=1   ← whole mask rejected
```

It went unnoticed because the package had **no decode test** — only registration + header-`Inspect` (which subscribes to `BASIC_INFO` alone and worked). The `testdata/sample_tile.jxl` fixture existed but was only used for `Inspect`; the decode test was explicitly deferred in a code comment.

## Fix

Subscribe to `JXL_DEC_BASIC_INFO | JXL_DEC_FULL_IMAGE` only. `ProcessInput` still emits `NEED_IMAGE_OUT_BUFFER` on its own, handled in the existing loop. One-line change to the C subscription call.

## Test plan

- [x] New **`TestDecodeSampleTile`** — decodes the committed 240×240 `.jxl` tile (RGB, RGBA, and decode-into-`Dst`) and asserts real, non-uniform pixels. This is the end-to-end gate that was missing. Runs in the cgo CI jobs (which have libjxl).
- [x] Verified end-to-end: `jxl-out.tiff` (generic-TIFF, Compression 50002) `DecodedTile(0,0)` now returns 240×240 pixels (was "corrupt input data").
- [x] Full `./...` green; `go vet`; nocgo build + jpegxl stub test pass.
- [x] Confirmed sibling cgo codecs (avif/webp/htj2k/jpeg2000) decode correctly — JPEG-XL was the only broken one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)