### PR TITLE
Reader metadata + codec-tag fixes (#106, #108, #110)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,39 @@ The single source of truth for "what was deferred and why" is
 front-page summary; the deferred file has the full reasoning,
 upstream references, and retirement audit per milestone.
 
+## [0.61.0] — 2026-07-12
+
+Reader metadata + codec-tag fixes: JP2K Aperio 33005 on the pyramid path,
+OME-TIFF `<Microscope>` scanner identity, and generic-TIFF acquisition-time
+preservation.
+
+### Added
+
+- **JPEG 2000 Aperio code 33005 (JP2K RGB) on the pyramid path (#110).** The
+  decoder + pyramid classifiers recognized 33003 (Aperio YCbCr) and 34712, but
+  not 33005 (Aperio JP2K RGB) — so a pyramid whose tiles are tagged 33005 was
+  undecodable/unclassifiable (33005 was handled only for associated images).
+  33005 is now registered in `decoder/jpeg2000` `TIFFCompressionTags`, the
+  generic-TIFF + OME-TIFF tiled compression mapping, and `internal/tiff`
+  pyramid-compression validation. Color (RGB vs YCbCr) is decided from the
+  codestream, not the tag, so an RGB/MCT 33005 codestream decodes as RGB with no
+  color-logic change. Unblocks wsitools emitting 33005 for RGB J2K.
+- **OME-TIFF scanner identity from the typed `<Microscope>` element (#106).**
+  The reader now parses `<Instrument><Microscope Manufacturer/Model/SerialNumber>`
+  and the image's `<InstrumentRef>`, resolving the primary image's instrument
+  (or the sole instrument) to populate `ScannerManufacturer` / `ScannerModel` /
+  `ScannerSerial`. New public `ometiff.OMEInstrument` type,
+  `OMEMetadata.Instruments`, and `OMEImage.InstrumentRefID`. Typed-element
+  counterpart to the existing Leica StructuredAnnotations path.
+
+### Fixed
+
+- **generic-TIFF: date-only provenance no longer zeroes the acquisition time
+  (#108).** A wsitools provenance `date=` parsed as date-only overrode the full
+  `DateTime`(306) tag, truncating `HH:MM:SS` to midnight. The reader now parses
+  `date=` as a full timestamp (RFC3339 / `2006-01-02T15:04:05`) when present, and
+  a date-only value never overrides a more-precise 306 tag.
+
 ## [0.60.2] — 2026-07-07
 
 ### Fixed

--- a/decoder/jpeg2000/jp2_cgo.go
+++ b/decoder/jpeg2000/jp2_cgo.go
@@ -1,9 +1,10 @@
 //go:build cgo && !nocgo && !nojp2k
 
 // Package jpeg2000 implements the JPEG 2000 decoder via openjp2.
-// TIFF Compression=33003 (Aperio convention) and 34712 (libtiff
-// convention). Does not support IDCT-time scaling; Decode rejects
-// DecodeOptions.Scale != 1.
+// TIFF Compression=33003 (Aperio JP2K YCbCr convention), 33005 (Aperio
+// JP2K RGB convention), and 34712 (libtiff convention). Color (RGB vs
+// YCbCr) is decided from the codestream, not the tag (see decodeIsYCbCr).
+// Does not support IDCT-time scaling; Decode rejects DecodeOptions.Scale != 1.
 package jpeg2000
 
 /*
@@ -271,7 +272,7 @@ func init() {
 type factory struct{}
 
 func (f *factory) Name() string                  { return "jpeg2000" }
-func (f *factory) TIFFCompressionTags() []uint16 { return []uint16{33003, 34712} }
+func (f *factory) TIFFCompressionTags() []uint16 { return []uint16{33003, 33005, 34712} }
 func (f *factory) New() decoder.Decoder          { return &cgoDecoder{} }
 
 // Inspect parses the JPEG 2000 main header (SIZ + COD, and the JP2 box structure

--- a/decoder/jpeg2000/jp2_nocgo.go
+++ b/decoder/jpeg2000/jp2_nocgo.go
@@ -15,7 +15,7 @@ func init() {
 type stubFactory struct{}
 
 func (f *stubFactory) Name() string                  { return "jpeg2000" }
-func (f *stubFactory) TIFFCompressionTags() []uint16 { return []uint16{33003, 34712} }
+func (f *stubFactory) TIFFCompressionTags() []uint16 { return []uint16{33003, 33005, 34712} }
 func (f *stubFactory) New() decoder.Decoder          { return &stubDecoder{} }
 
 type stubDecoder struct{}

--- a/decoder/jpeg2000/jp2_test.go
+++ b/decoder/jpeg2000/jp2_test.go
@@ -14,10 +14,12 @@ func TestRegistered(t *testing.T) {
 		t.Fatalf("jpeg2000 decoder not registered")
 	}
 	tags := f.TIFFCompressionTags()
-	if len(tags) < 2 {
-		t.Errorf("expected at least 2 tags (Aperio 33003 + libtiff 34712), got %v", tags)
+	if len(tags) < 3 {
+		t.Errorf("expected at least 3 tags (Aperio 33003 YCbCr + 33005 RGB + libtiff 34712), got %v", tags)
 	}
-	wantTags := map[uint16]bool{33003: false, 34712: false}
+	// 33005 is the Aperio JP2K RGB convention (#110), the counterpart to
+	// 33003 (YCbCr); both must be decodable on the pyramid path.
+	wantTags := map[uint16]bool{33003: false, 33005: false, 34712: false}
 	for _, tag := range tags {
 		if _, want := wantTags[tag]; want {
 			wantTags[tag] = true

--- a/formats/generictiff/tiled.go
+++ b/formats/generictiff/tiled.go
@@ -338,8 +338,9 @@ func (l *tiledImage) warm() error {
 //	7     JPEG             → CompressionJPEG
 //	8     Deflate          → CompressionDeflate (v0.10 addition)
 //	32946 AdobeDeflate     → CompressionDeflate (same payload as 8)
-//	33003 JP2K (Aperio)    → CompressionJP2K
-//	34712 JP2K (registered) → CompressionJP2K (v0.14 addition)
+//	33003 JP2K (Aperio YCbCr) → CompressionJP2K
+//	33005 JP2K (Aperio RGB)   → CompressionJP2K (#110)
+//	34712 JP2K (registered)   → CompressionJP2K (v0.14 addition)
 //	50001 WebP             → CompressionWebP   (v0.14 addition)
 //	50002 JPEG XL          → CompressionJPEGXL (v0.14 addition)
 //	60001 AVIF             → CompressionAVIF   (v0.14 addition)
@@ -358,7 +359,7 @@ func tiffCompressionToOpentile(comp uint32) opentile.Compression {
 		return opentile.CompressionJPEG
 	case 8, 32946:
 		return opentile.CompressionDeflate
-	case 33003, 34712:
+	case 33003, 33005, 34712:
 		return opentile.CompressionJP2K
 	case 50001:
 		return opentile.CompressionWebP

--- a/formats/generictiff/tiler.go
+++ b/formats/generictiff/tiler.go
@@ -249,7 +249,10 @@ func buildMetadata(p *tiff.Page) Metadata {
 			if wt.hasScanner {
 				md.ScannerManufacturer = wt.scannerManufacturer
 			}
-			if wt.hasDate {
+			// Only override the DateTime(306) tag when the provenance value is at
+			// least as precise: a date-only provenance must not zero out a 306 tag
+			// that already carries HH:MM:SS (#108).
+			if wt.hasDate && (wt.dateHasTime || md.AcquisitionDateTime.IsZero()) {
 				md.AcquisitionDateTime = wt.acquisitionDate
 			}
 			if wt.hasMPP {

--- a/formats/generictiff/wsitools.go
+++ b/formats/generictiff/wsitools.go
@@ -27,6 +27,7 @@ type wsiToolsMetadata struct {
 	hasScanner          bool
 	scannerManufacturer string
 	hasDate             bool
+	dateHasTime         bool // provenance date= carried an explicit HH:MM:SS
 	acquisitionDate     time.Time
 	hasMPP              bool
 	micronsPerPixel     float64
@@ -77,9 +78,14 @@ func parseWSIToolsDescription(desc string) (wsiToolsMetadata, bool) {
 				md.hasScanner = true
 			}
 		case "date":
-			if ts, err := time.Parse("2006-01-02", val); err == nil {
+			// Accept a full timestamp (wsitools now emits RFC3339, #108/wsitools#31)
+			// before the legacy date-only form, so acquisition TIME round-trips.
+			// dateHasTime records whether a time component was present, so a
+			// date-only value never clobbers a more-precise DateTime(306) tag.
+			if ts, hasTime, ok := parseProvenanceDate(val); ok {
 				md.acquisitionDate = ts.UTC()
 				md.hasDate = true
+				md.dateHasTime = hasTime
 			}
 		case "mpp":
 			if f, err := strconv.ParseFloat(val, 64); err == nil {
@@ -156,4 +162,22 @@ func tokeniseKVPairs(desc string) []string {
 		out = append(out, current.String())
 	}
 	return out
+}
+
+// parseProvenanceDate parses a wsitools provenance date= value. It accepts a
+// full timestamp (RFC3339, or "2006-01-02T15:04:05" / "2006-01-02 15:04:05")
+// before the legacy date-only "2006-01-02". hasTime reports whether an explicit
+// HH:MM:SS was present, so a date-only value never overrides a more-precise
+// DateTime(306) tag (#108).
+func parseProvenanceDate(val string) (ts time.Time, hasTime, ok bool) {
+	val = strings.TrimSpace(val)
+	for _, layout := range []string{time.RFC3339, "2006-01-02T15:04:05", "2006-01-02 15:04:05"} {
+		if t, err := time.Parse(layout, val); err == nil {
+			return t, true, true
+		}
+	}
+	if t, err := time.Parse("2006-01-02", val); err == nil {
+		return t, false, true
+	}
+	return time.Time{}, false, false
 }

--- a/formats/generictiff/wsitools_test.go
+++ b/formats/generictiff/wsitools_test.go
@@ -27,9 +27,55 @@ func TestParseWSIToolsDescription_HappyPath(t *testing.T) {
 	if !md.acquisitionDate.Equal(want) {
 		t.Errorf("date = %v, want %v", md.acquisitionDate, want)
 	}
+	if md.dateHasTime {
+		t.Error("dateHasTime = true for a date-only value, want false (#108)")
+	}
 	// v0.20: Version extracted for Writer population.
 	if md.Version != "0.2.0-dev" {
 		t.Errorf("Version = %q, want 0.2.0-dev", md.Version)
+	}
+}
+
+// TestParseWSIToolsDescription_FullTimestampDate: a full-timestamp provenance
+// date= must round-trip the HH:MM:SS (#108), not be truncated to midnight.
+func TestParseWSIToolsDescription_FullTimestampDate(t *testing.T) {
+	desc := `wsi-tools/0.26.0 transcode source=svs date=2009-12-29T09:59:15Z`
+	md, ok := parseWSIToolsDescription(desc)
+	if !ok || !md.hasDate {
+		t.Fatal("expected date parsed")
+	}
+	if !md.dateHasTime {
+		t.Error("dateHasTime = false, want true for an RFC3339 value")
+	}
+	want := time.Date(2009, 12, 29, 9, 59, 15, 0, time.UTC)
+	if !md.acquisitionDate.Equal(want) {
+		t.Errorf("date = %v, want %v (time component lost)", md.acquisitionDate, want)
+	}
+}
+
+func TestParseProvenanceDate(t *testing.T) {
+	cases := []struct {
+		in      string
+		wantHMS bool
+		want    time.Time
+	}{
+		{"2009-12-29T09:59:15Z", true, time.Date(2009, 12, 29, 9, 59, 15, 0, time.UTC)},
+		{"2009-12-29T09:59:15", true, time.Date(2009, 12, 29, 9, 59, 15, 0, time.UTC)},
+		{"2009-12-29 09:59:15", true, time.Date(2009, 12, 29, 9, 59, 15, 0, time.UTC)},
+		{"2009-12-29", false, time.Date(2009, 12, 29, 0, 0, 0, 0, time.UTC)},
+	}
+	for _, c := range cases {
+		ts, hasTime, ok := parseProvenanceDate(c.in)
+		if !ok {
+			t.Errorf("%q: ok=false, want parseable", c.in)
+			continue
+		}
+		if hasTime != c.wantHMS || !ts.UTC().Equal(c.want) {
+			t.Errorf("%q: got (%v, hasTime=%v), want (%v, hasTime=%v)", c.in, ts.UTC(), hasTime, c.want, c.wantHMS)
+		}
+	}
+	if _, _, ok := parseProvenanceDate("not-a-date"); ok {
+		t.Error("garbage input: ok=true, want false")
 	}
 }
 

--- a/formats/ometiff/metadata.go
+++ b/formats/ometiff/metadata.go
@@ -38,6 +38,13 @@ type OMEImage struct {
 	// cross-format Metadata layer to populate Magnification (v0.17).
 	ObjectiveSettingsID string
 
+	// InstrumentRefID is the <InstrumentRef ID> attribute's value,
+	// identifying which <Instrument> acquired this Image. Empty when
+	// absent. Resolved against OMEMetadata.Instruments (by ID) at the
+	// cross-format Metadata layer to populate ScannerManufacturer /
+	// ScannerModel / ScannerSerial from the linked <Microscope> (#106).
+	InstrumentRefID string
+
 	PhysicalSizeX     float64
 	PhysicalSizeY     float64
 	PhysicalSizeXUnit string
@@ -88,6 +95,17 @@ type OMEObjective struct {
 	LensNA                  float64
 }
 
+// OMEInstrument mirrors an <Instrument> element's identity: its ID and the
+// scanner make/model/serial from the child <Microscope> element (#106). The
+// cross-format Metadata layer resolves an Image's InstrumentRefID against this
+// list (by ID) to populate ScannerManufacturer / ScannerModel / ScannerSerial.
+type OMEInstrument struct {
+	ID           string
+	Manufacturer string
+	Model        string
+	SerialNumber string
+}
+
 // OMEMetadata is the top-level parsed view of an OME-XML document.
 // Holds the Image list in document order; further interpretation
 // (classification of macro / label / thumbnail vs main pyramid) is
@@ -108,6 +126,11 @@ type OMEMetadata struct {
 	// resolver (Image.ObjectiveSettingsID → Objective.ID) at the
 	// cross-format Metadata layer (v0.17).
 	Objectives []OMEObjective
+
+	// Instruments is every <Instrument> in document order, with its
+	// <Microscope> make/model/serial (#106). Used by the scanner-identity
+	// resolver (Image.InstrumentRefID → Instrument.ID).
+	Instruments []OMEInstrument
 
 	Images []OMEImage
 }
@@ -139,6 +162,12 @@ func parseOMEMetadata(xmlStr string) (OMEMetadata, error) {
 		Images:  make([]OMEImage, 0, len(doc.Images)),
 	}
 	for _, inst := range doc.Instruments {
+		out.Instruments = append(out.Instruments, OMEInstrument{
+			ID:           inst.ID,
+			Manufacturer: inst.Microscope.Manufacturer,
+			Model:        inst.Microscope.Model,
+			SerialNumber: inst.Microscope.SerialNumber,
+		})
 		for _, obj := range inst.Objectives {
 			out.Objectives = append(out.Objectives, OMEObjective{
 				ID:                      obj.ID,
@@ -158,6 +187,7 @@ func parseOMEMetadata(xmlStr string) (OMEMetadata, error) {
 			Description:         strings.TrimSpace(im.Description),
 			AcquisitionDate:     strings.TrimSpace(im.AcquisitionDate),
 			ObjectiveSettingsID: im.ObjectiveSettings.ID,
+			InstrumentRefID:     im.InstrumentRef.ID,
 			PhysicalSizeX:       im.Pixels.PhysicalSizeX,
 			PhysicalSizeY:       im.Pixels.PhysicalSizeY,
 			PhysicalSizeXUnit:   im.Pixels.PhysicalSizeXUnit,
@@ -188,7 +218,16 @@ type omeDoc struct {
 
 type omeInstrument struct {
 	ID         string         `xml:"ID,attr"`
+	Microscope omeMicroscope  `xml:"Microscope"`
 	Objectives []omeObjective `xml:"Objective"`
+}
+
+// omeMicroscope mirrors the <Microscope> element under <Instrument>, carrying
+// the source scanner identity (#106).
+type omeMicroscope struct {
+	Manufacturer string `xml:"Manufacturer,attr"`
+	Model        string `xml:"Model,attr"`
+	SerialNumber string `xml:"SerialNumber,attr"`
 }
 
 type omeObjective struct {
@@ -202,8 +241,15 @@ type omeImage struct {
 	Name              string               `xml:"Name,attr"`
 	AcquisitionDate   string               `xml:"AcquisitionDate"`
 	Description       string               `xml:"Description"`
+	InstrumentRef     omeInstrumentRef     `xml:"InstrumentRef"`
 	ObjectiveSettings omeObjectiveSettings `xml:"ObjectiveSettings"`
 	Pixels            omePixels            `xml:"Pixels"`
+}
+
+// omeInstrumentRef mirrors the <InstrumentRef ID> element linking an <Image>
+// to the <Instrument> that acquired it (#106).
+type omeInstrumentRef struct {
+	ID string `xml:"ID,attr"`
 }
 
 type omeObjectiveSettings struct {
@@ -253,14 +299,17 @@ type omeChannel struct {
 //   - Properties[ome.creator] from <OME Creator> root attribute.
 //   - Properties[ome.uuid] from <OME UUID> root attribute.
 //
-// Fields NOT populated (the OME fixtures we have don't carry them
-// in the parsed form, and adding them would require parsing
-// StructuredAnnotations OriginalMetadata which is a separate effort):
-//   - ScannerManufacturer / ScannerModel / ScannerSerial — Leica
-//     fixtures stash these in StructuredAnnotations OriginalMetadata
-//     keys like "macro device.model for image" rather than the
-//     typed <Microscope> element.
-//   - ScannerSoftware — same StructuredAnnotations source.
+//   - ScannerManufacturer / ScannerModel / ScannerSerial from the primary
+//     image's linked <Instrument><Microscope> element, resolved via
+//     <InstrumentRef> (or the sole Instrument) (#106).
+//
+// Fields NOT populated:
+//   - ScannerManufacturer / ScannerModel / ScannerSerial when carried ONLY in
+//     Leica's StructuredAnnotations OriginalMetadata (keys like
+//     "macro device.model for image") rather than the typed <Microscope>
+//     element — parsing OriginalMetadata is a separate effort. The typed
+//     <Microscope> path above IS populated.
+//   - ScannerSoftware — StructuredAnnotations OriginalMetadata source.
 //   - PropertyUserName — neither Leica fixture carries an
 //     <Experimenter> element. Code path is in place but inactive
 //     until a fixture surfaces one.
@@ -336,7 +385,41 @@ func crossMetadata(om OMEMetadata, cls omeClassification) opentile.Metadata {
 		}
 	}
 
+	// Scanner identity: resolve the primary image's <InstrumentRef> against the
+	// Instruments list, then read the linked <Microscope> make/model/serial
+	// (#106) — the typed-element counterpart to the Leica StructuredAnnotations
+	// OriginalMetadata path.
+	if inst, ok := resolveInstrument(om, primary.InstrumentRefID); ok {
+		if inst.Manufacturer != "" {
+			md.ScannerManufacturer = inst.Manufacturer
+		}
+		if inst.Model != "" {
+			md.ScannerModel = inst.Model
+		}
+		if inst.SerialNumber != "" {
+			md.ScannerSerial = inst.SerialNumber
+		}
+	}
+
 	return md
+}
+
+// resolveInstrument returns the OMEInstrument that an image's InstrumentRefID
+// points to. When refID is empty or unmatched it falls back to the sole
+// Instrument if the file has exactly one (an unambiguous single-instrument
+// link). ok=false when no instrument can be resolved (#106).
+func resolveInstrument(om OMEMetadata, refID string) (OMEInstrument, bool) {
+	if refID != "" {
+		for _, inst := range om.Instruments {
+			if inst.ID == refID {
+				return inst, true
+			}
+		}
+	}
+	if len(om.Instruments) == 1 {
+		return om.Instruments[0], true
+	}
+	return OMEInstrument{}, false
 }
 
 // convertToMicrons normalises a PhysicalSize value + Unit attribute to

--- a/formats/ometiff/metadata_test.go
+++ b/formats/ometiff/metadata_test.go
@@ -266,6 +266,67 @@ func TestCrossMetadataMagnificationFallback(t *testing.T) {
 	}
 }
 
+// TestParseInstrumentMicroscope: <Instrument><Microscope> and the image's
+// <InstrumentRef> parse from OME-XML (#106).
+func TestParseInstrumentMicroscope(t *testing.T) {
+	xmlStr := `<OME>` +
+		`<Instrument ID="Instrument:0"><Microscope Manufacturer="Aperio" Model="GT450" SerialNumber="SN-12345"/></Instrument>` +
+		`<Image ID="Image:0" Name="main"><InstrumentRef ID="Instrument:0"/>` +
+		`<Pixels SizeX="100" SizeY="100" SizeC="3" Type="uint8"/></Image>` +
+		`</OME>`
+	om, err := parseOMEMetadata(xmlStr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(om.Instruments) != 1 {
+		t.Fatalf("Instruments = %d, want 1", len(om.Instruments))
+	}
+	i := om.Instruments[0]
+	if i.ID != "Instrument:0" || i.Manufacturer != "Aperio" || i.Model != "GT450" || i.SerialNumber != "SN-12345" {
+		t.Errorf("Instrument = %+v, want Instrument:0/Aperio/GT450/SN-12345", i)
+	}
+	if om.Images[0].InstrumentRefID != "Instrument:0" {
+		t.Errorf("InstrumentRefID = %q, want Instrument:0", om.Images[0].InstrumentRefID)
+	}
+}
+
+// TestCrossMetadataScannerFromMicroscope: the primary image's linked
+// <Microscope> populates ScannerManufacturer/Model/Serial (#106).
+func TestCrossMetadataScannerFromMicroscope(t *testing.T) {
+	om := OMEMetadata{
+		Instruments: []OMEInstrument{
+			{ID: "Instrument:0", Manufacturer: "Aperio", Model: "GT450", SerialNumber: "SN-1"},
+		},
+		Images: []OMEImage{{Name: "main", InstrumentRefID: "Instrument:0"}},
+	}
+	cls := omeClassification{LevelImages: []int{0}, Macro: -1, Label: -1, Thumbnail: -1}
+	md := crossMetadata(om, cls)
+	if md.ScannerManufacturer != "Aperio" || md.ScannerModel != "GT450" || md.ScannerSerial != "SN-1" {
+		t.Errorf("scanner = %q/%q/%q, want Aperio/GT450/SN-1",
+			md.ScannerManufacturer, md.ScannerModel, md.ScannerSerial)
+	}
+}
+
+func TestResolveInstrument(t *testing.T) {
+	two := OMEMetadata{Instruments: []OMEInstrument{
+		{ID: "Instrument:0", Manufacturer: "A"},
+		{ID: "Instrument:1", Manufacturer: "B"},
+	}}
+	if inst, ok := resolveInstrument(two, "Instrument:1"); !ok || inst.Manufacturer != "B" {
+		t.Errorf("ref match = %+v ok=%v, want B/true", inst, ok)
+	}
+	if _, ok := resolveInstrument(two, "Instrument:9"); ok {
+		t.Error("unmatched ref with 2 instruments: ok=true, want false (no ambiguous fallback)")
+	}
+	one := OMEMetadata{Instruments: []OMEInstrument{{ID: "x", Manufacturer: "Solo"}}}
+	if inst, ok := resolveInstrument(one, ""); !ok || inst.Manufacturer != "Solo" {
+		t.Errorf("sole-instrument fallback = %+v ok=%v, want Solo/true", inst, ok)
+	}
+	if _, ok := resolveInstrument(OMEMetadata{}, ""); ok {
+		t.Error("no instruments: ok=true, want false")
+	}
+}
+
 // TestConvertToMicrons: verify the unit table.
 func TestConvertToMicrons(t *testing.T) {
 	cases := []struct {

--- a/formats/ometiff/tiled.go
+++ b/formats/ometiff/tiled.go
@@ -371,7 +371,7 @@ func tiffCompressionToOpentile(tiffCode uint32) opentile.Compression {
 		return opentile.CompressionJPEG
 	case 8, 32946:
 		return opentile.CompressionDeflate
-	case 33003, 34712:
+	case 33003, 33005, 34712:
 		return opentile.CompressionJP2K
 	}
 	return opentile.CompressionUnknown

--- a/internal/tiff/classify_pyramid.go
+++ b/internal/tiff/classify_pyramid.go
@@ -123,6 +123,7 @@ func validPhotometric(photo uint32) bool {
 // TIFF compression tag values:
 //
 //   - v0.10: 1 (None), 5 (LZW), 7 (JPEG), 8 (Deflate), 33003 (JPEG 2000)
+//   - 33005 — Aperio JP2K RGB convention (#110; counterpart to 33003 YCbCr)
 //   - v0.14 additions:
 //   - 34712 — registered JP2K code (libtiff convention; we already
 //     accept Aperio's nonstandard 33003)
@@ -132,7 +133,7 @@ func validPhotometric(photo uint32) bool {
 //   - 60003 — HTJ2K (wsi-tools convention; private/experimental range)
 func validCompression(comp uint32) bool {
 	switch comp {
-	case 1, 5, 7, 8, 33003,
+	case 1, 5, 7, 8, 33003, 33005,
 		34712, 50001, 50002, 60001, 60003:
 		return true
 	default:

--- a/internal/tiff/classify_pyramid_test.go
+++ b/internal/tiff/classify_pyramid_test.go
@@ -337,6 +337,7 @@ func TestValidCompression(t *testing.T) {
 		{"JPEG", 7, true},
 		{"Deflate", 8, true},
 		{"JP2K_Aperio", 33003, true},
+		{"JP2K_Aperio_RGB", 33005, true}, // #110
 
 		// v0.14 additions
 		{"JP2K_registered", 34712, true},


### PR DESCRIPTION
Three independent reader fixes (one commit each), closes #106 / #108 / #110. Targets **v0.61.0**.

## #110 — JPEG 2000 Aperio code 33005 (JP2K RGB) on the pyramid path
The JP2K decoder + pyramid classifiers recognized 33003 (Aperio YCbCr) and 34712, but **not 33005** (Aperio JP2K RGB) — so a pyramid whose tiles are tagged 33005 was undecodable (`codec not registered for tag 33005`) and didn't classify (33005 was handled only for *associated* images). Registered 33005 in `decoder/jpeg2000` `TIFFCompressionTags` (cgo + nocgo), the generic-TIFF + OME-TIFF tiled compression mapping, and `internal/tiff.validCompression`. Color (RGB vs YCbCr) is already decided from the codestream (`decodeIsYCbCr`, GH#53), not the tag, so an RGB/MCT 33005 codestream decodes as RGB — no color-logic change. Unblocks wsitools#44. (A tag-aware RGB *default* for an ambiguous 33005 codestream is deferred — needs the tag plumbed to the tag-agnostic decoder, and real 33005 encoders emit MCT/sRGB.)

## #106 — OME-TIFF scanner identity from typed `<Microscope>`
The reader ignored `<Instrument><Microscope Manufacturer/Model/SerialNumber>`, so a wsitools OME-TIFF carrying a standard `<Microscope>` round-tripped empty. Now parses `<Microscope>` + the image's `<InstrumentRef>`, resolves the primary image's instrument (or the sole instrument) → `ScannerManufacturer`/`ScannerModel`/`ScannerSerial`. New public `ometiff.OMEInstrument`, `OMEMetadata.Instruments`, `OMEImage.InstrumentRefID`. Round-trips wsitools#27.

## #108 — generic-TIFF: date-only provenance zeroed acquisition time
A wsitools provenance `date=` parsed as date-only overrode the full `DateTime`(306) tag, truncating `HH:MM:SS` to midnight (`2009-12-29T09:59:15Z → 00:00:00`). Now (1) parses `date=` as a full timestamp (RFC3339 / `2006-01-02T15:04:05`) before the legacy date-only form, and (2) a date-only value never overrides a more-precise 306 tag.

## Test plan
- [x] #110: `TIFFCompressionTags` + `validCompression` include 33005 (unit tests). JP2K decode itself already tested (aperio/RGB-MCT).
- [x] #106: XML-parse test (`<Microscope>`/`<InstrumentRef>`), `crossMetadata` resolution test, `resolveInstrument` unit test (ref match / sole-instrument fallback / no-fallback / none).
- [x] #108: full-timestamp round-trip + `parseProvenanceDate` layout table + date-only-doesn't-override.
- [x] Full `./...` green; `go vet`; nocgo build. Additive public API (OME types); no behavior change for existing slides beyond the fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)